### PR TITLE
View\FolderDesignDocument didn't support Windows

### DIFF
--- a/lib/Doctrine/CouchDB/View/FolderDesignDocument.php
+++ b/lib/Doctrine/CouchDB/View/FolderDesignDocument.php
@@ -29,7 +29,7 @@ class FolderDesignDocument implements DesignDocument
             foreach ($ri AS $path) {
                 $fileData = $this->getFileData($path);
                 if ($fileData !== null) {
-                    $parts = explode("/", ltrim(str_replace($this->folderPath, '', $fileData["key"]), '/'));
+                    $parts = explode(DIRECTORY_SEPARATOR, ltrim(str_replace($this->folderPath, '', $fileData["key"]), DIRECTORY_SEPARATOR));
 
                     if (count($parts) == 3) {
                         $this->data[$parts[0]][$parts[1]][$parts[2]] = $fileData["data"];


### PR DESCRIPTION
Since View\FolderDesignDocument uses native php file system functions the getFileData _key_ is returned containing '\'s rather than the '/' used in the subsequent trim and explode. Using the DIRECTORY_SEPARATOR constant rather than '/' provides support for Windows.
