### PR TITLE
Make DesignDocument Parameter Optional

### DIFF
--- a/lib/Doctrine/CouchDB/CouchDBClient.php
+++ b/lib/Doctrine/CouchDB/CouchDBClient.php
@@ -365,7 +365,7 @@ class CouchDBClient
      * @param DesignDocument $designDoc
      * @return View\Query
      */
-    public function createViewQuery($designDocName, $viewName, DesignDocument $designDoc)
+    public function createViewQuery($designDocName, $viewName, DesignDocument $designDoc = null)
     {
         return new View\Query($this->httpClient, $this->databaseName, $designDocName, $viewName, $designDoc);
     }


### PR DESCRIPTION
The `DesignDocument` parameter to `CouchDBClient::createViewQuery` should be optional, as it truly is optional. It is not needed, but the current interface forces me to provide it.
