### PR TITLE
Adding keys parameter in View Query

### DIFF
--- a/lib/Doctrine/CouchDB/View/Query.php
+++ b/lib/Doctrine/CouchDB/View/Query.php
@@ -48,12 +48,27 @@ class Query extends AbstractQuery
     /**
      * Find key in view.
      *
-     * @param  string $val
+     * @param  string|array $val
      * @return Query
      */
     public function setKey($val)
     {
+        if (is_array($val)) {
+            return $this->setKeys($val);
+        }
         $this->params['key'] = $val;
+        return $this;
+    }
+
+    /**
+     * Find keys in the view
+     *
+     * @param  array $values
+     * @return Query
+     */
+    public function setKeys(array $values)
+    {
+        $this->params['keys'] = $values;
         return $this;
     }
 


### PR DESCRIPTION
As described in the documentation a View Query can have an array of keys to fetch.

This change enables fetching multiple keys from the View

http://wiki.apache.org/couchdb/HTTP_view_API#Querying_Options
