### PR TITLE
Support query parameters for couchdb changes.

### DIFF
--- a/lib/Doctrine/CouchDB/CouchDBClient.php
+++ b/lib/Doctrine/CouchDB/CouchDBClient.php
@@ -277,10 +277,23 @@ class CouchDBClient
      * @param  array $params
      * @return array
      */
-    public function getChanges(array $params = null)
+    public function getChanges(array $params = array())
     {
         $path = '/' . $this->databaseName . '/_changes';
-        $response = $this->httpClient->request('GET', $path, $params);
+
+        if (count($params) > 0) {
+
+            foreach ($params as $key => $value) {
+                if (isset($params[$key]) === true && is_bool($value) === true) {
+                    $params[$key] = ($value) ? 'true': 'false';
+                }
+            }
+
+            $query = http_build_query($params);
+            $path = $path.'?'.$query;
+        }
+
+        $response = $this->httpClient->request('GET', $path);
 
         if ($response->status != 200) {
             throw HTTPException::fromResponse($path, $response);

--- a/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
@@ -104,6 +104,45 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
         $this->assertArrayHasKey('results', $changes);
         $this->assertEquals(2, count($changes['results']));
         $this->assertEquals(2, $changes['last_seq']);
+
+        // Check the limit parameter.
+        $changes = $this->couchClient->getChanges(array(
+            'limit' => 1,
+        ));
+        $this->assertArrayHasKey('results', $changes);
+        $this->assertEquals(1, count($changes['results']));
+        $this->assertEquals(1, $changes['last_seq']);
+
+        // Checks the descending parameter.
+        $changes = $this->couchClient->getChanges(array(
+            'descending' => true,
+        ));
+
+        $this->assertArrayHasKey('results', $changes);
+        $this->assertEquals(2, count($changes['results']));
+        $this->assertEquals(1, $changes['last_seq']);
+
+        // Checks the since parameter.
+        $changes = $this->couchClient->getChanges(array(
+            'since' => 1,
+        ));
+
+        $this->assertArrayHasKey('results', $changes);
+        $this->assertEquals(1, count($changes['results']));
+        $this->assertEquals(2, $changes['last_seq']);
+
+        // Checks the filter parameter.
+        $designDocPath = __DIR__ . "/../../Models/CMS/_files";
+
+        // Create a filter, that filters the only doc with {"_id":"test1"}
+        $client = $this->couchClient;
+        $client->createDesignDocument('test-filter', new FolderDesignDocument($designDocPath));
+
+        $changes = $this->couchClient->getChanges(array(
+            'filter' => 'test-filter/my_filter'
+        ));
+        $this->assertEquals(1, count($changes['results']));
+        $this->assertEquals(3, $changes['last_seq']);
     }
 
     public function testPostDocument()

--- a/tests/Doctrine/Tests/Models/CMS/_files/filters/my_filter.js
+++ b/tests/Doctrine/Tests/Models/CMS/_files/filters/my_filter.js
@@ -1,0 +1,8 @@
+function(doc) {
+
+    if (doc._id == 'test1') {
+        return true;
+    }
+
+    return false;
+}


### PR DESCRIPTION
Query parameters can now be used to query the changes feed, see
http://wiki.apache.org/couchdb/HTTP_database_API#Changes for further
details.
