### PR TITLE
Fix stale queries

### DIFF
--- a/lib/Doctrine/CouchDB/View/Query.php
+++ b/lib/Doctrine/CouchDB/View/Query.php
@@ -36,12 +36,21 @@ class Query extends AbstractQuery
 
     protected function getHttpQuery()
     {
+        $arguments = array();
+        foreach ($this->params as $key => $value) {
+            if ($key === 'stale') {
+                $arguments[$key] = $value;
+            } else {
+                $arguments[$key] = json_encode($value);
+            }
+        }
+
         return sprintf(
             "/%s/_design/%s/_view/%s?%s",
             $this->databaseName,
             $this->designDocumentName,
             $this->viewName,
-            http_build_query( array_map( "json_encode", $this->params ) )
+            http_build_query($arguments)
         );
     }
 


### PR DESCRIPTION
Stale queries didn't work as the argument value was json_encoded
and thus not recognized as being "ok" or "update_ok" by CouchDB.
This change introduces an exception just for the 'stale' argument.
