### PR TITLE
Added getter for total_rows information on view results

### DIFF
--- a/lib/Doctrine/CouchDB/View/Result.php
+++ b/lib/Doctrine/CouchDB/View/Result.php
@@ -28,6 +28,11 @@ class Result implements \IteratorAggregate, \Countable, \ArrayAccess
         $this->result = $result;
     }
 
+    public function getTotalRows()
+    {
+        return $this->result['total_rows'];
+    }
+
     public function getIterator()
     {
         return new \ArrayIterator($this->result['rows']);


### PR DESCRIPTION
The total_rows information cannot be accessed right now via `Result` objects and the getter would make this possible. Would that be a acceptable solution to you @beberlei?
