### PR TITLE
Switching to POST request and encoding "keys" in POST body when "keys" p...

### DIFF
--- a/lib/Doctrine/CouchDB/View/AbstractQuery.php
+++ b/lib/Doctrine/CouchDB/View/AbstractQuery.php
@@ -80,12 +80,19 @@ abstract class AbstractQuery
     protected function doExecute()
     {
         $path = $this->getHttpQuery();
-        $response = $this->client->request("GET", $path);
+        $method = "GET";
+        $data = null;
+        if($this->getParameter("keys") !== null) {
+  	      $method = "POST";
+          $data = json_encode(array("keys" => $this->getParameter("keys")));
+        }
+
+        $response = $this->client->request($method, $path, $data);
 
         if ( $response instanceof ErrorResponse ) {
             // Create view, if it does not exist yet
             $this->createDesignDocument();
-            $response = $this->client->request( "GET", $path );
+            $response = $this->client->request($method, $path, $data);
         }
 
         if ($response->status >= 400) {

--- a/lib/Doctrine/CouchDB/View/Query.php
+++ b/lib/Doctrine/CouchDB/View/Query.php
@@ -40,7 +40,7 @@ class Query extends AbstractQuery
         foreach ($this->params as $key => $value) {
             if ($key === 'stale') {
                 $arguments[$key] = $value;
-            } else {
+            } else if($key != 'keys') {
                 $arguments[$key] = json_encode($value);
             }
         }


### PR DESCRIPTION
Switching to POST request and encoding "keys" in POST body when "keys" parameter is present.

Using a keys query array as query param in a GET request does not seem to work very well (At least for me working with a BigCouch instance the keys are ignored completely). The CouchDb documentation suggests to use a POST request with the requested keys encoded in the post body (this works in my setup).