### PR TITLE
Updated URL-template for couchdb-lucene >= 1.0

### DIFF
--- a/lib/Doctrine/CouchDB/View/LuceneQuery.php
+++ b/lib/Doctrine/CouchDB/View/LuceneQuery.php
@@ -30,9 +30,9 @@ class LuceneQuery extends AbstractQuery
     protected function getHttpQuery()
     {
         return sprintf(
-            "/%s/%s/_design/%s/%s?%s",
-            $this->databaseName,
+            "/%s/local/%s/_design/%s/%s?%s",
             $this->handlerName,
+            $this->databaseName,
             $this->designDocumentName,
             $this->viewName,
             http_build_query( $this->params )


### PR DESCRIPTION
Some days ago couchdb-lucene 1.0 was released and i think it brought some changes to the Proxy/Api URL structure as you can see in my small patch. The code above worked for my setup (CouchDB 1.5.0 & couchdb-lucene 1.0 & CouchDB-Client & CouchDB-ODM).