### PR TITLE
Set language property

### DIFF
--- a/lib/Doctrine/CouchDB/View/FolderDesignDocument.php
+++ b/lib/Doctrine/CouchDB/View/FolderDesignDocument.php
@@ -40,6 +40,8 @@ class FolderDesignDocument implements DesignDocument
                     }
                 }
             }
+
+            $this->data['language'] = 'javascript';
         }
 
         return $this->data;


### PR DESCRIPTION
If no language is set, Futon does not allow to edit the views. They
still work, but this is kind of annoying.
