### PR TITLE
More allDocs params

### DIFF
--- a/lib/Doctrine/CouchDB/CouchDBClient.php
+++ b/lib/Doctrine/CouchDB/CouchDBClient.php
@@ -180,9 +180,12 @@ class CouchDBClient
      *
      * @param int|null $limit
      * @param string|null $startKey
+     * @param string|null $endKey
+     * @param int|null $skip
+     * @param bool $descending
      * @return HTTP\Response
      */
-    public function allDocs($limit = null, $startKey = null)
+    public function allDocs($limit = null, $startKey = null, $endKey = null, $skip = null, $descending = false)
     {
         $allDocsPath = '/' . $this->databaseName . '/_all_docs?include_docs=true';
         if ($limit) {
@@ -190,6 +193,15 @@ class CouchDBClient
         }
         if ($startKey) {
             $allDocsPath .= '&startkey="' . (string)$startKey.'"';
+        }
+        if (!is_null($endKey)) {
+            $allDocsPath .= '&endkey="' . (string)$endKey.'"';
+        }
+        if (!is_null($skip) && (int)$skip > 0) {
+            $allDocsPath .= '&skip=' . (int)$skip;
+        }
+        if (!is_null($descending) && (bool)$descending === true) {
+            $allDocsPath .= '&descending=true';
         }
         return $this->httpClient->request('GET', $allDocsPath);
     }

--- a/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
@@ -306,7 +306,7 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
         $ids = array();
         $expectedRows = array();
         foreach (range(1, 3) as $i) {
-            list($id, $rev) = $client->putDocument(array('foo' => 'bar' . $i), (string)$i);
+            list($id, $rev) = $client->postDocument(array('foo' => 'bar' . $i));
             $ids[] = $id;
             // This structure might be dependent from couchdb version. Tested against v1.6.1
             $expectedRows[] = array(

--- a/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
@@ -237,6 +237,7 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
         list($firstId, $firstRev) = $client->postDocument(array("foo" => "bar"));
         list($secondId, $secondRev) = $client->postDocument(array("alpha" => "beta"));
 
+        // Everything
         $response = $client->allDocs();
 
         $this->assertEquals(200, $response->status);
@@ -245,15 +246,31 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
 
         // Limit
         $response = $client->allDocs(1);
-
-        $this->assertEquals(200, $response->status);
         $this->assertTrue(strpos(json_encode($response->body), $firstId) > 0);
         $this->assertTrue(strpos(json_encode($response->body), $secondId) == 0);
 
         // Start key
         $response = $client->allDocs(null, $secondId);
+        $this->assertTrue(strpos(json_encode($response->body), $firstId) == 0);
+        $this->assertTrue(strpos(json_encode($response->body), $secondId) > 0);
 
-        $this->assertEquals(200, $response->status);
+        // End key
+        $response = $client->allDocs(null, null, $firstId);
+        $this->assertTrue(strpos(json_encode($response->body), $firstId) > 0);
+        $this->assertTrue(strpos(json_encode($response->body), $secondId) == 0);
+
+        // Skip
+        $response = $client->allDocs(null, null, null, 1);
+        $this->assertTrue(strpos(json_encode($response->body), $firstId) == 0);
+        $this->assertTrue(strpos(json_encode($response->body), $secondId) > 0);
+
+        // Skip, Descending
+        $response = $client->allDocs(null, null, null, 1, true);
+        $this->assertTrue(strpos(json_encode($response->body), $firstId) > 0);
+        $this->assertTrue(strpos(json_encode($response->body), $secondId) == 0);
+
+        // Limit, Descending
+        $response = $client->allDocs(1, null, null, null, true);
         $this->assertTrue(strpos(json_encode($response->body), $firstId) == 0);
         $this->assertTrue(strpos(json_encode($response->body), $secondId) > 0);
 

--- a/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
@@ -225,4 +225,42 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
 
         $client->compactView('test-design-doc-query');
     }
+
+    public function testAllDocs()
+    {
+        $client = $this->couchClient;
+
+        // Start clean
+        $client->deleteDatabase($this->getTestDatabase());
+        $client->createDatabase($this->getTestDatabase());
+
+        list($firstId, $firstRev) = $client->postDocument(array("foo" => "bar"));
+        list($secondId, $secondRev) = $client->postDocument(array("alpha" => "beta"));
+
+        $response = $client->allDocs();
+
+        $this->assertEquals(200, $response->status);
+        $this->assertTrue(strpos(json_encode($response->body), $firstId) > 0);
+        $this->assertTrue(strpos(json_encode($response->body), $secondId) > 0);
+
+        // Limit
+        $response = $client->allDocs(1);
+
+        $this->assertEquals(200, $response->status);
+        $this->assertTrue(strpos(json_encode($response->body), $firstId) > 0);
+        $this->assertTrue(strpos(json_encode($response->body), $secondId) == 0);
+
+        // Start key
+        $response = $client->allDocs(null, $secondId);
+
+        $this->assertEquals(200, $response->status);
+        $this->assertTrue(strpos(json_encode($response->body), $firstId) == 0);
+        $this->assertTrue(strpos(json_encode($response->body), $secondId) > 0);
+
+
+
+        // tidy
+        $client->deleteDocument($firstId, $firstRev);
+        $client->deleteDocument($secondId, $secondRev);
+    }
 }

--- a/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
@@ -58,6 +58,9 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
 
         $dbs = $this->couchClient->getAllDatabases();
         $this->assertContains($dbName2, $dbs);
+
+        // Tidy
+        $this->couchClient->deleteDatabase($dbName2);
     }
 
     public function testDropMultipleTimesSkips()
@@ -395,6 +398,10 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
         $client->replicate($sourceDatabase, $targetDatabase2, true, true);
         $active_tasks = $client->getActiveTasks();
         $this->assertEquals(array(), $active_tasks);
+
+        // Tidy
+        $this->couchClient->deleteDatabase($targetDatabase1);
+        $this->couchClient->deleteDatabase($targetDatabase2);
     }
 
     public function testGetRevisionDifference()


### PR DESCRIPTION
To allow users more flexibility when querying all documents, endKey, skip and descending have been added as optional parameters to the method, with unit tests before and after the new functionality to assert expected behaviour and backwards compatibility.

This may be a fix for request https://github.com/doctrine/couchdb-client/issues/24

Happy to make amends if you feel that I've strayed from the coding style or proposed functionality of the library.