### PR TITLE
Fix getDatabaseInfo not using its parameter for database name

### DIFF
--- a/lib/Doctrine/CouchDB/CouchDBClient.php
+++ b/lib/Doctrine/CouchDB/CouchDBClient.php
@@ -270,7 +270,7 @@ class CouchDBClient
      */
     public function getDatabaseInfo($name)
     {
-        $response = $this->httpClient->request('GET', '/' . $this->databaseName);
+        $response = $this->httpClient->request('GET', '/' . urlencode($name));
 
         if ($response->status != 200) {
             throw HTTPException::fromResponse('/' . urlencode($name), $response);


### PR DESCRIPTION
It seems that `getDatabaseInfo` in `CouchDBClient` was using $this->database instead of the $name passed as parameter. At least it seems inconsistent with create/deleteDatabase methods... But let me know if that's not a bug and that's me that is not using the method properly :wink: 