### PR TITLE
Gsoc: Add getRevisionDifference method with test, add header support to SocketClient and StreamClient, add POST support to getChanges method, add methods to BulkUpdater with tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor
+.idea

--- a/lib/Doctrine/CouchDB/CouchDBClient.php
+++ b/lib/Doctrine/CouchDB/CouchDBClient.php
@@ -282,7 +282,7 @@ class CouchDBClient
     /**
      * Get changes.
      *
-     * @param  array $params
+     * @param array $params
      * @return array
      * @throws HTTPException
      */
@@ -290,20 +290,26 @@ class CouchDBClient
     {
         $path = '/' . $this->databaseName . '/_changes';
 
-        if (count($params) > 0) {
+        $method = ((!isset($params['doc_ids']) || $params['doc_ids'] == null) ? "GET" : "POST");
+        $response = '';
+
+        if ($method == "GET") {
 
             foreach ($params as $key => $value) {
                 if (isset($params[$key]) === true && is_bool($value) === true) {
                     $params[$key] = ($value) ? 'true': 'false';
                 }
             }
+            if (count($params) > 0) {
+                $query = http_build_query($params);
+                $path = $path.'?'.$query;
+            }
+            $response = $this->httpClient->request('GET', $path);
 
-            $query = http_build_query($params);
-            $path = $path.'?'.$query;
+        } else {
+            $path .= '?filter=_doc_ids';
+            $response = $this->httpClient->request('POST', $path, json_encode($params));
         }
-
-        $response = $this->httpClient->request('GET', $path);
-
         if ($response->status != 200) {
             throw HTTPException::fromResponse($path, $response);
         }

--- a/lib/Doctrine/CouchDB/CouchDBClient.php
+++ b/lib/Doctrine/CouchDB/CouchDBClient.php
@@ -542,4 +542,21 @@ class CouchDBClient
         }
         return $response->body;
     }
+
+    /**
+     * Get revision difference.
+     *
+     * @param  array $data
+     * @return array
+     * @throws HTTPException
+     */
+    public function getRevisionDifference($data)
+    {
+        $path = '/' . $this->databaseName . '/_revs_diff';
+        $response = $this->httpClient->request('POST', $path, json_encode($data));
+        if ($response->status != 200) {
+            throw HTTPException::fromResponse($path, $response);
+        }
+        return $response->body;
+    }
 }

--- a/lib/Doctrine/CouchDB/HTTP/Client.php
+++ b/lib/Doctrine/CouchDB/HTTP/Client.php
@@ -27,13 +27,16 @@ interface Client
      * Perform a request to the server and return the result converted into a
      * Response object. If you do not expect a JSON structure, which
      * could be converted in such a response object, set the fourth parameter to
-     * true, and you get a response object retuerned, containing the raw body.
+     * true, and you get a response object returned, containing the raw body.
+     * Optional HTTP request headers can be passed in an array using the fifth
+     * parameter.
      *
      * @param string $method
      * @param string $path
      * @param string $data
      * @param bool $raw
+     * @param array $headers
      * @return Response
      */
-    function request( $method, $path, $data = null, $raw = false );
+    function request( $method, $path, $data = null, $raw = false, array $headers = array() );
 }

--- a/lib/Doctrine/CouchDB/HTTP/StreamClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/StreamClient.php
@@ -38,20 +38,30 @@ class StreamClient extends AbstractHTTPClient
      * Perform a request to the server and return the result converted into a
      * Response object. If you do not expect a JSON structure, which
      * could be converted in such a response object, set the forth parameter to
-     * true, and you get a response object retuerned, containing the raw body.
+     * true, and you get a response object returned, containing the raw body.
      *
      * @param string $method
      * @param string $path
      * @param string $data
      * @param bool $raw
+     * @param array $headers
      * @return Response
      * @throws HTTPException
      */
-    public function request( $method, $path, $data = null, $raw = false )
+    public function request( $method, $path, $data = null, $raw = false, array $headers = array())
     {
         $basicAuth = '';
         if ( $this->options['username'] ) {
             $basicAuth .= "{$this->options['username']}:{$this->options['password']}@";
+        }
+        if (!isset($headers['Content-Type'])) {
+            $headers['Content-Type'] = 'application/json';
+        }
+        $stringHeader = '';
+        if ($headers != null) {
+            foreach ($headers as $key => $val) {
+                $stringHeader .= $key . ": " . $val . "\r\n";
+            }
         }
 
         // TODO SSL support?
@@ -68,7 +78,7 @@ class StreamClient extends AbstractHTTPClient
                         'max_redirects' => 0,
                         'user_agent'    => 'Doctrine CouchDB ODM $Revision$',
                         'timeout'       => $this->options['timeout'],
-                        'header'        => 'Content-type: application/json',
+                        'header'        => $stringHeader,
                     ),
                 )
             )
@@ -118,12 +128,13 @@ class StreamClient extends AbstractHTTPClient
             );
         }
 
-        // Create repsonse object from couch db response
+        // Create response object from couch db response
         if ( $headers['status'] >= 400 )
         {
             return new ErrorResponse( $headers['status'], $headers, $body );
         }
         return new Response( $headers['status'], $headers, $body, $raw );
     }
+
 }
 

--- a/lib/Doctrine/CouchDB/Utils/BulkUpdater.php
+++ b/lib/Doctrine/CouchDB/Utils/BulkUpdater.php
@@ -34,6 +34,8 @@ class BulkUpdater
 {
     private $data = array('docs' => array());
 
+    private $requestHeaders = array();
+
     private $httpClient;
 
     private $databaseName;
@@ -59,9 +61,19 @@ class BulkUpdater
         $this->data['docs'][] = array('_id' => $id, '_rev' => $rev, '_deleted' => true);
     }
 
+    public function setNewEdits($newEdits)
+    {
+        $this->data["new_edits"] = (bool)$newEdits;
+    }
+
+    public function setFullCommitHeader($commit)
+    {
+        $this->requestHeaders['X-Couch-Full-Commit'] = (bool)$commit;
+    }
+
     public function execute()
     {
-        return $this->httpClient->request('POST', $this->getPath(), json_encode($this->data));
+        return $this->httpClient->request('POST', $this->getPath(), json_encode($this->data), false, $this->requestHeaders);
     }
 
     public function getPath()

--- a/lib/Doctrine/CouchDB/Utils/BulkUpdater.php
+++ b/lib/Doctrine/CouchDB/Utils/BulkUpdater.php
@@ -56,6 +56,13 @@ class BulkUpdater
         $this->data['docs'][] = $data;
     }
 
+    public function updateDocuments(array $docs)
+    {
+        foreach ($docs as $doc) {
+            $this->data['docs'][] = (is_array($doc) ? $doc : json_decode($doc, true));
+        }
+    }
+
     public function deleteDocument($id, $rev)
     {
         $this->data['docs'][] = array('_id' => $id, '_rev' => $rev, '_deleted' => true);

--- a/tests/Doctrine/Tests/CouchDB/CouchDBFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/CouchDB/CouchDBFunctionalTestCase.php
@@ -31,8 +31,18 @@ abstract class CouchDBFunctionalTestCase extends \PHPUnit_Framework_TestCase
         return TestUtil::getTestDatabase();
     }
 
+    public function getBulkTestDatabase()
+    {
+        return TestUtil::getBulkTestDatabase();
+    }
+
     public function createCouchDBClient()
     {
         return new CouchDBClient($this->getHttpClient(), $this->getTestDatabase());
+    }
+
+    public function createCouchDBClientForBulkTest()
+    {
+        return new CouchDBClient($this->getHttpClient(), $this->getBulkTestDatabase());
     }
 }

--- a/tests/Doctrine/Tests/CouchDB/Functional/BulkUpdaterTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/BulkUpdaterTest.php
@@ -54,8 +54,8 @@ class BulkUpdaterTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCase
         $response = $this->bulkUpdater->execute();
         $revTest1 = $response->body[0]["rev"];
 
-        //test with all_or_nothing=false
-        //try to update one doc with wrong or no _rev. Only test1 should be updated.
+        // Test with all_or_nothing=false.
+        // Try to update one doc with wrong or no _rev say test2. Only test1 should be updated.
         $bulkUpdater2 = $this->couchClient->createBulkUpdater();
         $bulkUpdater2->setAllOrNothing(false);
         $docs2 = $docs;
@@ -68,9 +68,9 @@ class BulkUpdaterTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCase
         $this->assertEquals(true, isset($response->body[0]["ok"]));
         $this->assertEquals(false, isset($response->body[1]["ok"]));
 
-        //test with all_or_nothing=true
-        //try to update one doc with wrong or no _rev. Still both doc should get updated in case if there is any update
-        // at all.
+        // Test with all_or_nothing=true.
+        // Try to update one doc with wrong or no _rev say test2. Still both doc should get updated in case if there is
+        // any update at all.
         $bulkUpdater3 = $this->couchClient->createBulkUpdater();
         $bulkUpdater3->setAllOrNothing(true);
         $docs3 = $docs;
@@ -94,7 +94,7 @@ class BulkUpdaterTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCase
         $this->bulkUpdater->updateDocument($doc);
         $response = $this->bulkUpdater->execute();
         $response = $this->couchClient->findDocument("test1");
-        //_rev remains same
+        // _rev remains same.
         $this->assertEquals($doc, $response->body);
 
     }
@@ -110,7 +110,7 @@ class BulkUpdaterTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCase
         $this->bulkUpdater->updateDocument($docs["test2"]);
         $response = $this->bulkUpdater->execute();
 
-        //insert the rev values
+        // Insert the rev values.
         foreach ($response->body as $res) {
             $docs[$res['id']]['_rev'] = $res['rev'];
         }
@@ -132,7 +132,7 @@ class BulkUpdaterTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCase
         $this->bulkUpdater->updateDocuments($docs);
         $response = $this->bulkUpdater->execute();
 
-        //insert the rev values
+        // Insert the rev values.
         foreach ($response->body as $res) {
             $id = $res['id'];
             if ($id == 'test1') {

--- a/tests/Doctrine/Tests/CouchDB/Functional/BulkUpdaterTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/BulkUpdaterTest.php
@@ -1,0 +1,174 @@
+<?php
+
+
+namespace Doctrine\Tests\CouchDB\Functional;
+
+use Doctrine\CouchDB\CouchDBClient;
+use Doctrine\CouchDB\Utils\BulkUpdater;
+
+class BulkUpdaterTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCase
+{
+    /**
+     * @var CouchDBClient
+     */
+    private $couchClient;
+
+    /**
+     * @var BulkUpdater
+     */
+    private $bulkUpdater;
+
+    public function setUp()
+    {
+        $this->couchClient = $this->createCouchDBClientForBulkTest();
+        $this->couchClient->createDatabase($this->getTestDatabase() . "_bulk");
+        $this->bulkUpdater = $this->couchClient->createBulkUpdater();
+    }
+
+    public function testGetPath()
+    {
+        $this->assertEquals(
+            '/' . $this->getTestDatabase() . '_bulk' . '/_bulk_docs',
+            $this->bulkUpdater->getpath()
+        );
+    }
+
+    /**
+     * @depends testGetPath
+     */
+    public function testExecute()
+    {
+        $response = $this->bulkUpdater->execute();
+        $this->assertEquals(201, $response->status);
+        $this->assertEquals(array(), $response->body);
+    }
+
+    /**
+     * @depends testExecute
+     */
+    public function testSetAllOrNothing()
+    {
+        $docs[] = array("_id" => "test1", "foo" => "bar");
+        $docs[] = array("_id" => "test2", "bar" => "baz");
+        $this->bulkUpdater->updateDocuments($docs);
+        $response = $this->bulkUpdater->execute();
+        $revTest1 = $response->body[0]["rev"];
+
+        //test with all_or_nothing=false
+        //try to update one doc with wrong or no _rev. Only test1 should be updated.
+        $bulkUpdater2 = $this->couchClient->createBulkUpdater();
+        $bulkUpdater2->setAllOrNothing(false);
+        $docs2 = $docs;
+        $docs2[0]["should_be_updated"] = "true";
+        $docs2[0]["_rev"] = $revTest1;
+        $docs2[1]["should_be_updated"] = "false";
+        $bulkUpdater2->updateDocuments($docs2);
+        $response = $bulkUpdater2->execute();
+        $this->assertEquals(2, count($response->body));
+        $this->assertEquals(true, isset($response->body[0]["ok"]));
+        $this->assertEquals(false, isset($response->body[1]["ok"]));
+
+        //test with all_or_nothing=true
+        //try to update one doc with wrong or no _rev. Still both doc should get updated in case if there is any update
+        // at all.
+        $bulkUpdater3 = $this->couchClient->createBulkUpdater();
+        $bulkUpdater3->setAllOrNothing(true);
+        $docs3 = $docs;
+        $docs3[0]["should_be_updated"] = "true";
+        $docs3[0]["_rev"] = $revTest1;
+        $docs3[1]["should_be_updated"] = "true";
+        $bulkUpdater3->updateDocuments($docs3);
+        $response = $bulkUpdater3->execute();
+        $this->assertEquals(2, count($response->body));
+        $this->assertEquals(true, isset($response->body[0]["ok"]));
+        $this->assertEquals(true, isset($response->body[1]["ok"]));
+    }
+
+    /**
+     * @depends testExecute
+     */
+    public function testSetNewEdits()
+    {
+        $this->bulkUpdater->setNewEdits(false);
+        $doc = array("_id" => "test1", "foo" => "bar", "_rev" => "10-gsoc");
+        $this->bulkUpdater->updateDocument($doc);
+        $response = $this->bulkUpdater->execute();
+        $response = $this->couchClient->findDocument("test1");
+        //_rev remains same
+        $this->assertEquals($doc, $response->body);
+
+    }
+
+    /**
+     * @depends testExecute
+     */
+    public function testUpdateDocument()
+    {
+        $docs["test1"] = array("_id" => "test1", "foo" => "bar");
+        $docs["test2"] = array("_id" => "test2", "bar" => "baz");
+        $this->bulkUpdater->updateDocument($docs["test1"]);
+        $this->bulkUpdater->updateDocument($docs["test2"]);
+        $response = $this->bulkUpdater->execute();
+
+        //insert the rev values
+        foreach ($response->body as $res) {
+            $docs[$res['id']]['_rev'] = $res['rev'];
+        }
+
+        $response = $this->couchClient->findDocument("test1");
+        $this->assertEquals($docs['test1'], $response->body);
+        $response = $this->couchClient->findDocument("test2");
+        $this->assertEquals($docs['test2'], $response->body);
+    }
+
+    /**
+     * @depends testExecute
+     */
+    public function testUpdateDocuments()
+    {
+        $docs[] = array("_id" => "test1", "foo" => "bar");
+        $docs[] = '{"_id": "test2","baz": "foo"}';
+
+        $this->bulkUpdater->updateDocuments($docs);
+        $response = $this->bulkUpdater->execute();
+
+        //insert the rev values
+        foreach ($response->body as $res) {
+            $id = $res['id'];
+            if ($id == 'test1') {
+                $docs[0]['_rev'] = $res['rev'];
+            } elseif ($id == 'test2') {
+                $docs[1] = substr($docs[1], 0, strlen($docs[1])-1) . ',"_rev": "'. $res['rev'] . '"}';
+            }
+        }
+
+        $response = $this->couchClient->findDocument("test1");
+        $this->assertEquals($docs[0], $response->body);
+        $response = $this->couchClient->findDocument("test2");
+        $this->assertEquals(json_decode($docs[1], true), $response->body);
+    }
+
+    /**
+     * @depends testExecute
+     */
+    public function testDeleteDocument()
+    {
+        $doc = array("_id" => "test1", "foo" => "bar");
+        $this->bulkUpdater->updateDocument($doc);
+        $response = $this->bulkUpdater->execute();
+        $rev = $response->body[0]["rev"];
+
+        $bulkUpdater2 = $this->couchClient->createBulkUpdater();
+        $bulkUpdater2->deleteDocument("test1", $rev);
+        $response = $bulkUpdater2->execute();
+        $response = $this->couchClient->findDocument("test1");
+        $this->assertEquals(404, $response->status);
+
+    }
+
+    public function tearDown()
+    {
+        $this->couchClient->deleteDatabase($this->getBulkTestDatabase());
+    }
+
+}

--- a/tests/Doctrine/Tests/CouchDB/Functional/BulkUpdaterTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/BulkUpdaterTest.php
@@ -21,14 +21,14 @@ class BulkUpdaterTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCase
     public function setUp()
     {
         $this->couchClient = $this->createCouchDBClientForBulkTest();
-        $this->couchClient->createDatabase($this->getTestDatabase() . "_bulk");
+        $this->couchClient->createDatabase($this->getBulkTestDatabase());
         $this->bulkUpdater = $this->couchClient->createBulkUpdater();
     }
 
     public function testGetPath()
     {
         $this->assertEquals(
-            '/' . $this->getTestDatabase() . '_bulk' . '/_bulk_docs',
+            '/' . $this->getBulkTestDatabase() . '/_bulk_docs',
             $this->bulkUpdater->getpath()
         );
     }

--- a/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
@@ -343,4 +343,56 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
         $active_tasks = $client->getActiveTasks();
         $this->assertEquals(array(), $active_tasks);
     }
+
+    public function testGetRevisionDifference()
+    {
+        $client = $this->couchClient;
+        $mapping = array (
+            'baz' =>
+                array (
+                    0 => '2-7051cbe5c8faecd085a3fa619e6e6337',
+                ),
+            'foo' =>
+                array (
+                    0 => '3-6a540f3d701ac518d3b9733d673c5484',
+                ),
+            'bar' =>
+                array (
+                    0 => '1-d4e501ab47de6b2000fc8a02f84a0c77',
+                    1 => '1-967a00dff5e02add41819138abb3284d',
+                ),
+        );
+        $revisionDifference = array (
+            'baz' =>
+                array (
+                    'missing' =>
+                        array (
+                            0 => '2-7051cbe5c8faecd085a3fa619e6e6337',
+                        ),
+                ),
+            'foo' =>
+                array (
+                    'missing' =>
+                        array (
+                            0 => '3-6a540f3d701ac518d3b9733d673c5484',
+                        ),
+                ),
+            'bar' =>
+                array (
+                    'missing' =>
+                        array (
+                            0 => '1-d4e501ab47de6b2000fc8a02f84a0c77',
+                            1 => '1-967a00dff5e02add41819138abb3284d',
+                        ),
+                ),
+        );
+
+        list($id, $rev) = $client->putDocument(array("name" => "test"), 'foo');
+        $mapping['foo'][] = $rev;
+        $revDiff = $client->getRevisionDifference($mapping);
+        if (isset($revDiff['foo']['possible_ancestors'])) {
+            $revisionDifference['foo']['possible_ancestors'] = $revDiff['foo']['possible_ancestors'];
+        }
+        $this->assertEquals($revisionDifference, $revDiff);
+    }
 }

--- a/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
@@ -106,7 +106,7 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
         $this->assertEquals(2, count($changes['results']));
         $this->assertEquals(2, $changes['last_seq']);
 
-        //check the doc_ids parameter
+        // Check the doc_ids parameter.
         $changes = $this->couchClient->getChanges(array(
             'doc_ids' => array('test1')
         ));

--- a/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
@@ -106,6 +106,23 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
         $this->assertEquals(2, count($changes['results']));
         $this->assertEquals(2, $changes['last_seq']);
 
+        //check the doc_ids parameter
+        $changes = $this->couchClient->getChanges(array(
+            'doc_ids' => array('test1')
+        ));
+        $this->assertArrayHasKey('results', $changes);
+        $this->assertEquals(1, count($changes['results']));
+        $this->assertArrayHasKey('id', $changes['results'][0]);
+        $this->assertEquals('test1', $changes['results'][0]['id']);
+        $this->assertEquals(2, $changes['last_seq']);
+
+        $changes = $this->couchClient->getChanges(array(
+            'doc_ids' => null
+        ));
+        $this->assertArrayHasKey('results', $changes);
+        $this->assertEquals(2, count($changes['results']));
+        $this->assertEquals(2, $changes['last_seq']);
+
         // Check the limit parameter.
         $changes = $this->couchClient->getChanges(array(
             'limit' => 1,

--- a/tests/Doctrine/Tests/CouchDB/TestUtil.php
+++ b/tests/Doctrine/Tests/CouchDB/TestUtil.php
@@ -11,4 +11,12 @@ class TestUtil
         }
         return 'doctrine_test_database';
     }
+
+    static public function getBulkTestDatabase()
+    {
+        if (isset($GLOBALS['DOCTRINE_COUCHDB_BULK_DATABASE'])) {
+            return $GLOBALS['DOCTRINE_COUCHDB_BULK_DATABASE'];
+        }
+        return 'doctrine_test_database_bulk';
+    }
 }


### PR DESCRIPTION
Hi..! I am working on a project under Google's summer of code program for Drupal which involves writing a php based replicator. I am following [this] (http://docs.couchdb.org/en/latest/replication/protocol.html) link for implementing the replication protocol and this is the first set of changes that i have made.
I will try to describe most of the changes that have been done in the client. Let's go file by file.

1. **CouchDBClient.php**
    1. In `getChanges()` method, whenever *doc_ids* parameter is set and is not null, *POST* is used instead of *GET* for the request as the number of document ids can be large and using the POST is also the recommended way. See [api/da    ase/changes](http://docs.couchdb.org/en/latest/api/database/changes.html#get--db-_changes).
    2. `getRevisionDifference()` method has been added to the CouchDBClient class which sends a *POST /{db}/_revs_diff* request.

2. **CouchDBClientTest.php**
    1. `testGetRevisionDifference()` has been added as the test for `getRevisionDifference()` method.
    2. Code for checking the *doc_ids* parameter has been added to the `testGetChanges()` method.

3. **BulkUpdater.php**
    1. `updateDocuments()` method has been added. It's like the existing `updateDocument()` method, but instead of a document it takes an array having documents as array or as JSON strings. It's more convenient to add multiple documents to the Updater.
    2. `setNewEdits()` method has been added, which sets the *new_edits* option to true/false. This prevents the database from assigning them new revision IDs and is needed for the replicator. It is also one of the options that request JSON for *POST /{db}/_bulk_docs* api can have. So it will also be a good feature addition.
    3. `setFullCommitHeader()` has been added and it sets the *X-Couch-Full-Commit* in the HTTP request header sent by the `execute()` method to true/false. It's needed for the replicator.
    4. `execute()` method has been modified for supporting custom HTTP request headers. Currently only *X-Couch-Full-Commit* is being sent.

4. **BulkUpdaterTest.php**
    This file has been added and contains the tests for BulkUpdater. This was not there initially and tests the new changes along with the pre-existing methods also. However there is no test for `setFullCommitHeader()` method.

5. **TestUtil.php**
    1. `getBulkTestDatabase()` method has been added which returns the name of the database to be used for tests in BulkUpdaterTest. It's like the existing `getTestDatabase()` method.

6. **CouchDBFunctionalTestCase.php**
    1. `getBulkTestDatabase()` method has been added which returns `TestUtil::getBulkTestDatabase()` ;
    2. `createCouchDBClientForBulkTest()` method has been added and returns an instance of CouchDBClient to be used in the tests for BulkUpdater.

7. **.gitignore**
    1. Added *.idea* to it. It can be ignored.

8. **SocketClient.php** and **StreamClient.php**
    1. Spelling errors in the inline comments have been corrected.
    2. Custom HTTP header support has been added to both the clients. The `request()` method takes the request headers also. This is needed as sometime we have to use the customer HTTP header like the above described *X-Couch-Full-Commit*, content type is not always *application/json* or the *Accept* header can be *multipart/mixed*. All this was not possible with the earlier clients and are needed for the requests of the replicator.
