### PR TITLE
Add getConnection(). Add getChangesAsStream() and transferChangedDocuments() with tests. Add MultipartParserAndSender with tests. Make some PSR-2 corrections. Remove support for PHP 5.3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ services:
   - couchdb
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         {"name": "Lukas Kahwe Smith", "email": "smith@pooteeweet.org"}
     ],
     "require": {
-        "php": ">=5.3.2",
+        "php": ">=5.4",
         "doctrine/common": "@stable"
     },
     "autoload": {

--- a/lib/Doctrine/CouchDB/CouchDBClient.php
+++ b/lib/Doctrine/CouchDB/CouchDBClient.php
@@ -299,7 +299,7 @@ class CouchDBClient
 
             foreach ($params as $key => $value) {
                 if (isset($params[$key]) === true && is_bool($value) === true) {
-                    $params[$key] = ($value) ? 'true': 'false';
+                    $params[$key] = ($value) ? 'true' : 'false';
                 }
             }
             if (count($params) > 0) {
@@ -580,7 +580,7 @@ class CouchDBClient
     public function transferChangedDocuments($docId, $missingRevs, CouchDBClient $target)
     {
         $path = '/' . $this->getDatabase() . '/' . $docId;
-        $params = array('revs' => true ,'latest' => true,'open_revs' => json_encode($missingRevs));
+        $params = array('revs' => true, 'latest' => true, 'open_revs' => json_encode($missingRevs));
         $query = http_build_query($params);
         $path .= '?' . $query;
 
@@ -613,7 +613,7 @@ class CouchDBClient
     public function getChangesAsStream(array $params = array())
     {
         // Set feed to continuous.
-        if (!isset($params['feed']) || $params['feed'] != "continuous") {
+        if (!isset($params['feed']) || $params['feed'] != 'continuous') {
             $params['feed'] = 'continuous';
         }
         $path = '/' . $this->databaseName . '/_changes';
@@ -626,18 +626,18 @@ class CouchDBClient
             $connectionOptions['ip'],
             $connectionOptions['ssl']
         );
-        $method = ((!isset($params['doc_ids']) || $params['docs_ids'] == null) ? "GET" : "POST");
+        $method = ((!isset($params['doc_ids']) || $params['docs_ids'] == null) ? 'GET' : 'POST');
         $stream = null;
 
-        if ($method == "GET") {
+        if ($method == 'GET') {
             foreach ($params as $key => $value) {
                 if (isset($params[$key]) === true && is_bool($value) === true) {
-                    $params[$key] = ($value) ? 'true': 'false';
+                    $params[$key] = ($value) ? 'true' : 'false';
                 }
             }
             if (count($params) > 0) {
                 $query = http_build_query($params);
-                $path = $path.'?'.$query;
+                $path = $path . '?' . $query;
             }
             $stream = $streamClient->getConnection('GET', $path, null);
         } else {

--- a/lib/Doctrine/CouchDB/CouchDBClient.php
+++ b/lib/Doctrine/CouchDB/CouchDBClient.php
@@ -21,6 +21,8 @@ namespace Doctrine\CouchDB;
 
 use Doctrine\CouchDB\HTTP\Client;
 use Doctrine\CouchDB\HTTP\HTTPException;
+use Doctrine\CouchDB\HTTP\MultipartParserAndSender;
+use Doctrine\CouchDB\HTTP\StreamClient;
 use Doctrine\CouchDB\Utils\BulkUpdater;
 use Doctrine\CouchDB\View\DesignDocument;
 
@@ -564,5 +566,100 @@ class CouchDBClient
             throw HTTPException::fromResponse($path, $response);
         }
         return $response->body;
+    }
+
+    /**
+     * Transfer missing revisions to the target.
+     *
+     * @param string $docId
+     * @param array $missingRevs
+     * @param CouchDBClient $target
+     * @return array|HTTP\ErrorResponse|string
+     * @throws HTTPException
+     */
+    public function transferChangedDocuments($docId, $missingRevs, CouchDBClient $target)
+    {
+        $path = '/' . $this->getDatabase() . '/' . $docId;
+        $params = array('revs' => true ,'latest' => true,'open_revs' => json_encode($missingRevs));
+        $query = http_build_query($params);
+        $path .= '?' . $query;
+
+        $targetPath = '/' . $target->getDatabase() . '/' . $docId . '?new_edits=false';
+
+        $mutltipartHandler = new MultipartParserAndSender($this->getHttpClient(), $target->getHttpClient());
+        return $mutltipartHandler->request(
+            'GET',
+            $path,
+            $targetPath,
+            null,
+            array('Accept' => 'multipart/mixed')
+        );
+
+    }
+
+    /**
+     * Get changes as a stream.
+     *
+     * This method similar to the getChanges() method. But instead of returning
+     * the set of changes, it returns the connection stream from which the response
+     * can be read line by line. This is useful when you want to continuously get changes
+     * as they occur.
+     *
+     * @param array $params
+     * @param bool $raw
+     * @return resource
+     * @throws HTTPException
+     */
+    public function getChangesAsStream(array $params = array())
+    {
+        // Set feed to continuous.
+        if (!isset($params['feed']) || $params['feed'] != "continuous") {
+            $params['feed'] = 'continuous';
+        }
+        $path = '/' . $this->databaseName . '/_changes';
+        $connectionOptions = $this->getHttpClient()->getOptions();
+        $streamClient = new StreamClient(
+            $connectionOptions['host'],
+            $connectionOptions['port'],
+            $connectionOptions['username'],
+            $connectionOptions['password'],
+            $connectionOptions['ip'],
+            $connectionOptions['ssl']
+        );
+        $method = ((!isset($params['doc_ids']) || $params['docs_ids'] == null) ? "GET" : "POST");
+        $stream = null;
+
+        if ($method == "GET") {
+            foreach ($params as $key => $value) {
+                if (isset($params[$key]) === true && is_bool($value) === true) {
+                    $params[$key] = ($value) ? 'true': 'false';
+                }
+            }
+            if (count($params) > 0) {
+                $query = http_build_query($params);
+                $path = $path.'?'.$query;
+            }
+            $stream = $streamClient->getConnection('GET', $path, null);
+        } else {
+            $stream = $streamClient->getConnection('POST', $path, json_encode($params));
+        }
+        $headers = $streamClient->getStreamHeaders($stream);
+        if (empty($headers['status'])) {
+            throw HTTPException::readFailure(
+                $connectionOptions['ip'],
+                $connectionOptions['port'],
+                'Received an empty response or not status code',
+                0
+            );
+        } elseif ($headers['status'] != 200) {
+            $body = '';
+            while (!feof($stream)) {
+                $body .= fgets($stream);
+            }
+            throw HTTPException::fromResponse($path, new Response($headers['status'], $headers, $body));
+        }
+        // Everything seems okay.
+        return $stream;
+
     }
 }

--- a/lib/Doctrine/CouchDB/HTTP/AbstractHTTPClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/AbstractHTTPClient.php
@@ -91,5 +91,15 @@ abstract class AbstractHTTPClient implements Client
             throw new \InvalidArgumentException( "Unknown option $option." );
         }
     }
+
+    /**
+     * Get the connection options.
+     *
+     * @return array
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
 }
 

--- a/lib/Doctrine/CouchDB/HTTP/Client.php
+++ b/lib/Doctrine/CouchDB/HTTP/Client.php
@@ -38,5 +38,22 @@ interface Client
      * @param array $headers
      * @return Response
      */
-    function request( $method, $path, $data = null, $raw = false, array $headers = array() );
+    function request($method, $path, $data = null, $raw = false, array $headers = array());
+
+    /**
+     * Return the connection pointer or connection socket after setting up the
+     * connection.
+     *
+     * Return the connection pointer (for stream connection) or connection
+     * socket (for socket connection) after setting up the connection. The
+     * returned resource can be used to read and write data in small chunks
+     * reducing the memory usage.
+     *
+     * @param string $method
+     * @param string $path
+     * @param string $data
+     * @param array $headers
+     * @return resource
+     */
+    function getConnection($method, $path, $data = null, array $headers = array());
 }

--- a/lib/Doctrine/CouchDB/HTTP/LoggingClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/LoggingClient.php
@@ -79,4 +79,35 @@ class LoggingClient implements Client
 
         return $response;
     }
+
+    public function getConnection(
+        $method,
+        $path,
+        $data = null,
+        array $headers = array()
+    ) {
+        $start = microtime(true);
+
+        $response = $this->client->getConnection(
+            $method,
+            $path,
+            $data,
+            $headers
+        );
+
+        $duration = microtime(true) - $start;
+        $this->requests[] = array(
+            'duration' => $duration,
+            'method' => $method,
+            'path' => rawurldecode($path),
+            'request' => $data,
+            'request_size' => strlen($data),
+            'response_status' => $response->status,
+            'response' => $response->body,
+            'response_headers' => $response->headers,
+        );
+        $this->totalDuration += $duration;
+
+        return $response;
+    }
 }

--- a/lib/Doctrine/CouchDB/HTTP/MultipartParserAndSender.php
+++ b/lib/Doctrine/CouchDB/HTTP/MultipartParserAndSender.php
@@ -98,14 +98,14 @@ class MultipartParserAndSender
                 fclose($this->sourceConnection);
             } catch (\Exception $e) {
 
-            } finally {
-                throw HTTPException::readFailure(
-                    $this->sourceClient->getOptions()['ip'],
-                    $this->sourceClient->getOptions()['port'],
-                    'Received an empty response or not status code',
-                    0
-                );
             }
+            throw HTTPException::readFailure(
+                $this->sourceClient->getOptions()['ip'],
+                $this->sourceClient->getOptions()['port'],
+                'Received an empty response or not status code',
+                0
+            );
+
 
         } elseif ($sourceResponseHeaders['status'] != 200) {
             while (!feof($this->sourceConnection)) {
@@ -115,13 +115,12 @@ class MultipartParserAndSender
                 fclose($this->sourceConnection);
             } catch (\Exception $e) {
 
-            } finally {
-                return new ErrorResponse(
-                    $sourceResponseHeaders['status'],
-                    $sourceResponseHeaders,
-                    $body
-                );
             }
+            return new ErrorResponse(
+                $sourceResponseHeaders['status'],
+                $sourceResponseHeaders,
+                $body
+            );
 
         } else {
             try {
@@ -130,15 +129,14 @@ class MultipartParserAndSender
                 //  attachments. These should be posted using the Bulk API.
                 // 2) Responses of posting docs with attachments.
                 $body = $this->parseAndSend($targetPath);
-                return $body;
-            } catch(\Exception $e) {
-                throw $e;
-            } finally {
                 try{
                     fclose($this->sourceConnection);
                 } catch (\Exception $e) {
 
                 }
+                return $body;
+            } catch(\Exception $e) {
+                throw $e;
             }
         }
     }

--- a/lib/Doctrine/CouchDB/HTTP/MultipartParserAndSender.php
+++ b/lib/Doctrine/CouchDB/HTTP/MultipartParserAndSender.php
@@ -1,0 +1,413 @@
+<?php
+
+
+namespace Doctrine\CouchDB\HTTP;
+
+
+/**
+ * Streams the multipart data from the source to the target and thus
+ * makes the transfer with lesser memory footprint.
+ *
+ * Class MultipartParserAndSender
+ * @package Doctrine\CouchDB\Utils
+ */
+class MultipartParserAndSender
+{
+    /**
+     * @var StreamClient
+     */
+    protected $sourceClient;
+
+    /**
+     * @var SocketClient
+     */
+    protected $targetClient;
+
+    /**
+     * @var resource
+     */
+    protected $sourceConnection;
+
+    /**
+     * @var resource
+     */
+    protected $targetConnection;
+
+    /**
+     * @param StreamClient $source
+     * @param SocketClient $target
+     */
+    public function __construct(AbstractHTTPClient $source, AbstractHTTPClient $target)
+    {
+        $sourceOptions = $source->getOptions();
+        $this->sourceClient = new StreamClient(
+            $sourceOptions['host'],
+            $sourceOptions['port'],
+            $sourceOptions['username'],
+            $sourceOptions['password'],
+            $sourceOptions['ip'],
+            $sourceOptions['ssl']
+        );
+
+        $targetOptions = $target->getOptions();
+        $this->targetClient = new SocketClient(
+            $targetOptions['host'],
+            $targetOptions['port'],
+            $targetOptions['username'],
+            $targetOptions['password'],
+            $targetOptions['ip'],
+            $targetOptions['ssl']
+        );
+    }
+
+    /**
+     * Perform request to the source, parse the multipart response,
+     * stream the documents with attachments to the target and return
+     * the responses along with docs that did not have any attachments.
+     *
+     * @param string $sourceMethod
+     * @param string $sourcePath
+     * @param string $targetPath
+     * @param string $sourceData
+     * @param array $sourceHeaders
+     * @return array|ErrorResponse|string
+     * @throws HTTPException
+     * @throws \Exception
+     */
+    public function request(
+        $sourceMethod,
+        $sourcePath,
+        $targetPath,
+        $sourceData = null,
+        array $sourceHeaders = array()
+    ) {
+        $this->sourceConnection = $this->sourceClient->getConnection(
+            $sourceMethod,
+            $sourcePath,
+            $sourceData,
+            $sourceHeaders
+        );
+        $sourceResponseHeaders = $this->sourceClient->getStreamHeaders();
+        $body = '';
+
+        if (empty($sourceResponseHeaders['status'])) {
+            throw HTTPException::readFailure(
+                $this->sourceOptions['ip'],
+                $this->sourceOptions['port'],
+                'Received an empty response or not status code',
+                0
+            );
+
+        } elseif ($sourceResponseHeaders['status'] >= 400) {
+            while (!feof($this->sourceConnection)) {
+                $body .= fgets($this->sourceConnection);
+            }
+            return new ErrorResponse($sourceResponseHeaders['status'], $sourceResponseHeaders, $body);
+
+        } else {
+            if ($sourceResponseHeaders['status'] == 200) {
+
+                // Body is an array containing:
+                //  1) Array of json string documents that don't have attachments. These should be posted using the bulk
+                //     api.
+                //  2) Responses of posting docs with attachments.
+                $body = $this->parseAndSend($targetPath);
+            }
+            return $body;
+        }
+    }
+
+
+    /**
+     * Read and return next line from the connection pointer.
+     * $maxLength parameter can be used to set the maximum length
+     * to be read.
+     *
+     * @param int $maxLength
+     * @return string
+     */
+    protected function getNextLineFromSourceConnection($maxLength = null)
+    {
+        if ($maxLength !== null) {
+            return fgets($this->sourceConnection, $maxLength);
+        } else {
+            return fgets($this->sourceConnection);
+        }
+    }
+
+    /**
+     * Parses multipart data. Returns an array having:
+     * 1) Array of json docs(string) that don't have attachments. These
+     * should be posted using the bulk api. and
+     * 2) Responses of posting docs with attachments.
+     *
+     * @param $targetPath
+     * @return array
+     * @throws \Exception
+     * @throws \HTTPException
+     */
+    protected function parseAndSend($targetPath)
+    {
+        // Main response boundary of the multipart stream.
+        $mainBoundary = trim($this->getNextLineFromSourceConnection());
+
+        // Docs that don't have attachment.
+        // These should be posted using bulk upload.
+        $docStack = array();
+
+        // Responses from posting docs that have attachments.
+        $responses = array();
+
+        while (!feof($this->sourceConnection)) {
+
+            $line = ltrim($this->getNextLineFromSourceConnection());
+            if ($line == '') {
+                continue;
+
+            } elseif (strpos($line, "Content-Type") !== false) {
+
+
+                list($header, $value) = explode(":", $line);
+                $header = trim($header);
+                $value = trim($value);
+                $boundary = '';
+
+                if (strpos($value, ";") !== false) {
+                    list($type, $info) = explode(";", $value, 2);
+                    $info = trim($info);
+
+                    // Get the boundary for the current doc.
+                    if (strpos($info, "boundary") !== false) {
+                        $boundary = $info;
+
+                    } elseif (strpos($info, "error") !== false) {
+
+                        // Missing revs at the source.
+                        // Continue till the end of this document.
+                        while (strpos($this->getNextLineFromSourceConnection(), $mainBoundary) === false) ;
+
+                    } else {
+
+                        throw new \Exception("Unknown parameter with Content-Type.");
+                    }
+
+                }
+                // Doc with attachments.
+                if (strpos($value, "multipart/related") !==false) {
+
+                    if ($boundary == '') {
+                        throw new \Exception("Boundary not set for multipart/related data.");
+                    }
+
+
+                    $boundary = explode("=",$boundary,2)[1];
+
+                    try {
+                        $responses[] = $this->sendStream(
+                            'PUT',
+                            $targetPath,
+                            $mainBoundary,
+                            array('Content-Type' => 'multipart/related; boundary=' . $boundary));
+                    } catch (\Exception $e) {
+                        $responses[] = $e;
+                    }
+
+
+                } elseif ($value == 'application/json') {
+                    // JSON doc without attachment.
+                    $jsonDoc = '';
+
+                    while(trim(($jsonDoc = $this->getNextLineFromSourceConnection())) == '');
+                    array_push($docStack, trim($jsonDoc));
+
+                    // Continue till the end of this document.
+                    while (strpos($this->getNextLineFromSourceConnection(), $mainBoundary) === false) ;
+
+                } else {
+                    throw new \UnexpectedValueException("This value is not supported.");
+                }
+            } else {
+                throw new \Exception('The first line is not the Content-Type.');
+            }
+        }
+        return array($docStack, $responses);
+    }
+
+
+    /**
+     * Reads multipart data from sourceConnection and streams it to the targetConnection.
+     * Returns the body of the request or the status code in case there is no body.
+     *
+     * @param $method
+     * @param $path
+     * @param $streamEnd
+     * @param array $requestHeaders
+     * @return mixed|string
+     * @throws \Exception
+     * @throws \HTTPException
+     */
+    protected function sendStream($method, $path, $streamEnd, $requestHeaders = array())
+    {
+        $dataStream = $this->sourceConnection;
+        if ($this->targetConnection == null) {
+            $this->targetConnection = $this->targetClient->getConnection();
+        }
+
+        // Read the json doc. Use _attachments field to find the total Content-Length and create the
+        // request header with initial doc data. At present CouchDB can't handle chunked data and needs Content-Length
+        // header.
+        $str = '';
+        $jsonFlag = 0;
+        $attachmentCount = 0;
+        $totalAttachmentLength = 0;
+        $streamLine = $this->getNextLineFromSourceConnection();
+        while (
+            $jsonFlag == 0 ||
+            ($jsonFlag == 1 &&
+                trim($streamLine) == ''
+            )
+        ) {
+            $str .= $streamLine;
+            if (strpos($streamLine,"Content-Type: application/json") !== false) {
+                $jsonFlag = 1;
+            }
+            $streamLine = $this->getNextLineFromSourceConnection();
+        }
+        $docBoundaryLength = strlen(explode("=",$requestHeaders['Content-Type'],2)[1]) + 2;
+        $json = json_decode($streamLine, true);
+        foreach ($json['_attachments'] as $docName => $metaData) {
+            // Quotes and a "/r/n"
+            $totalAttachmentLength += strlen('Content-Disposition: attachment; filename=') + strlen($docName) + 4;
+            $totalAttachmentLength += strlen('Content-Type: ') + strlen($metaData["content_type"]) + 2;
+            $totalAttachmentLength +=  strlen('Content-Length: ');
+            if (isset($metaData["encoding"])) {
+                $totalAttachmentLength += $metaData["encoded_length"] + strlen($metaData["encoded_length"]) + 2;
+                $totalAttachmentLength += strlen('Content-Encoding: ') + strlen($metaData["encoding"]) + 2;
+            } else {
+                $totalAttachmentLength += $metaData["length"] + strlen($metaData["length"]) + 2;
+            }
+            $totalAttachmentLength += 2;
+            $attachmentCount++;
+        }
+
+        // Add Content-Length to the headers.
+        $requestHeaders['Content-Length'] = strlen($str) + strlen($streamLine)
+            + $totalAttachmentLength + $attachmentCount * (2 + $docBoundaryLength) + $docBoundaryLength + 2;
+
+        $request = $this->targetClient->buildRequest($method, $path, null, $requestHeaders);
+
+        // Add the initial body data.
+        $request .= $str;
+
+        if ( fwrite( $this->targetConnection, $request ) === false ) {
+            $this->targetConnection = null;
+            $error = error_get_last();
+            throw HTTPException::connectionFailure(
+                $this->targetClient->getOptions()['ip'],
+                $this->targetClient->getOptions()['port'],
+                $error['message'],
+                0
+            );
+        }
+
+        // Write the rest of the data including attachments
+        // line by line or in chunks.
+        while(!feof($dataStream) &&
+            ($streamEnd === null ||
+                strpos($streamLine, $streamEnd) ===
+                false
+            )
+        ) {
+            $totalSent = 0;
+            $length = strlen($streamLine);
+            while($totalSent != $length) {
+                $sent = fwrite($this->targetConnection, substr($streamLine,$totalSent));
+                if ($sent === false) {
+                    throw new \HTTPException('Stream write error.');
+                } else {
+                    $totalSent += $sent;
+                }
+            }
+            // Use maxLength while reading the data as there may be no newlines
+            // in the binary and compressed attachments, or the lines may be
+            // very long.
+            $streamLine = $this->getNextLineFromSourceConnection(100000);
+        }
+
+        // Read response headers
+        $rawHeaders = '';
+        $headers = array(
+            'connection' => ( $this->targetClient->getOptions()['keep-alive'] ? 'Keep-Alive' : 'Close' ),
+        );
+
+
+        // Remove leading newlines, should not occur at all, actually.
+        while ( ( ( $line = fgets( $this->targetConnection ) ) !== false ) &&
+            ( ( $lineContent = rtrim( $line ) ) === '' ) );
+
+        // Throw exception, if connection has been aborted by the server, and
+        // leave handling to the user for now.
+        if ($line === false) {
+            // sendStream can't be called in recursion as the source stream can be
+            // read only once.
+            $error = error_get_last();
+            throw HTTPException::connectionFailure(
+                $this->targetClient->getOptions()['ip'],
+                $this->targetClient->getOptions()['port'],
+                $error['message'],
+                0
+            );
+        }
+
+        do {
+            // Also store raw headers for later logging
+            $rawHeaders .= $lineContent . "\n";
+            // Extract header values
+            if ( preg_match( '(^HTTP/(?P<version>\d+\.\d+)\s+(?P<status>\d+))S', $lineContent, $match ) )
+            {
+                $headers['version'] = $match['version'];
+                $headers['status']  = (int) $match['status'];
+            }
+            else
+            {
+                list( $key, $value ) = explode( ':', $lineContent, 2 );
+                $headers[strtolower( $key )] = ltrim( $value );
+            }
+        }  while ( ( ( $line = fgets( $this->targetConnection ) ) !== false ) &&
+            ( ( $lineContent = rtrim( $line ) ) !== '' ) );
+
+
+        // Read response body
+        $body = '';
+
+        // HTTP 1.1 supports chunked transfer encoding, if the according
+        // header is not set, just read the specified amount of bytes.
+        $bytesToRead = (int) ( isset( $headers['content-length'] ) ? $headers['content-length'] : 0 );
+        // Read body only as specified by chunk sizes, everything else
+        // are just footnotes, which are not relevant for us.
+        while ($bytesToRead > 0) {
+            $body .= $read = fgets( $this->targetConnection, $bytesToRead + 1 );
+            $bytesToRead -= strlen( $read );
+        }
+
+        // Reset the connection if the server asks for it.
+        if ($headers['connection'] !== 'Keep-Alive' || true) {
+            fclose( $this->targetConnection );
+            $this->targetConnection = null;
+        }
+        // Handle some response state as special cases
+        switch ($headers['status']) {
+            case 301:
+            case 302:
+            case 303:
+            case 307:
+                // Temporary redirect.
+                // sendStream can't be called in recursion as the source stream can be
+                // read only once.
+                throw HTTPException::fromResponse($path, new Response($headers['status'], $headers, $body));
+        }
+        return ($body != '' ? json_decode($body, true) : array("status" => $headers['status'])) ;
+    }
+
+
+}

--- a/lib/Doctrine/CouchDB/HTTP/SocketClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/SocketClient.php
@@ -39,9 +39,32 @@ class SocketClient extends AbstractHTTPClient
      */
     protected $connection;
 
-    public function getConnection()
-    {
+    /**
+     * Return the socket after setting up the connection to server and writing
+     * the headers.
+     *
+     * @return resource
+     * @throws HTTPException
+     */
+
+    public function getConnection(
+        $method,
+        $path,
+        $data = null,
+        array$headers = array()
+    ) {
         $this->checkConnection();
+        $stringHeader = $this->buildRequest($method, $path, $data, $headers);
+        // Send the build request to the server
+        if (fwrite($this->connection, $stringHeader) === false) {
+            // Reestablish which seems to have been aborted
+            //
+            // The recursion in this method might be problematic if the
+            // connection establishing mechanism does not correctly throw an
+            // exception on failure.
+            $this->connection = null;
+            return $this->getConnection($method, $path, $data, $headers);
+        }
         return $this->connection;
     }
 
@@ -79,9 +102,8 @@ class SocketClient extends AbstractHTTPClient
 
         // If the connection could not be established, fsockopen sadly does not
         // only return false (as documented), but also always issues a warning.
-        if ( ( $this->connection === null ) &&
-             ( ( $this->connection = @fsockopen($host, $this->options['port'], $errno, $errstr) ) === false ) )
-        {
+        if (($this->connection === null) &&
+             (($this->connection = @fsockopen($host, $this->options['port'], $errno, $errstr)) === false)) {
             // This is a bit hackisch...
             $this->connection = null;
             throw HTTPException::connectionFailure(
@@ -105,23 +127,26 @@ class SocketClient extends AbstractHTTPClient
      * @param array $headers
      * @return string
      */
-    public function buildRequest( $method, $path, $data = null, array $headers = array())
-    {
+    protected function buildRequest(
+        $method,
+        $path,
+        $data = null,
+        array $headers = array()
+    ) {
         // Create basic request headers
         $request = "$method $path HTTP/1.1\r\nHost: {$this->options['host']}\r\n";
 
         // Add basic auth if set
-        if ( $this->options['username'] )
-        {
-            $request .= sprintf( "Authorization: Basic %s\r\n",
-                base64_encode( $this->options['username'] . ':' . $this->options['password'] )
+        if ($this->options['username']) {
+            $request .= sprintf("Authorization: Basic %s\r\n",
+                base64_encode($this->options['username'] . ':' . $this->options['password'])
             );
         }
 
         // Set keep-alive header, which helps to keep to connection
         // initialization costs low, especially when the database server is not
         // available in the locale net.
-        $request .= "Connection: " . ( $this->options['keep-alive'] ? 'Keep-Alive' : 'Close' ) . "\r\n";
+        $request .= "Connection: " . ($this->options['keep-alive'] ? 'Keep-Alive' : 'Close') . "\r\n";
 
         if (!isset($headers['Content-Type'])) {
             $headers['Content-Type'] = 'application/json';
@@ -130,22 +155,18 @@ class SocketClient extends AbstractHTTPClient
             if (is_bool($value) === true) {
                 $value = ($value) ? 'true': 'false';
             }
-            $request .= $key . ": ". $value . "\r\n";
+            $request .= $key . ": " . $value . "\r\n";
         }
 
         // Also add headers and request body if data should be sent to the
         // server. Otherwise just add the closing mark for the header section
         // of the request.
-        if ( $data !== null )
-        {
-            $request .= "Content-Length: " . strlen( $data ) . "\r\n\r\n";
+        if ($data !== null) {
+            $request .= "Content-Length: " . strlen($data) . "\r\n\r\n";
             $request .= $data;
-        }
-        else
-        {
+        } else {
             $request .= "\r\n";
         }
-
         return $request;
     }
 
@@ -164,37 +185,35 @@ class SocketClient extends AbstractHTTPClient
      * @param array $headers
      * @return Response
      */
-    public function request( $method, $path, $data = null, $raw = false, array $headers = array() )
+    public function request($method, $path, $data = null, $raw = false, array $headers = array())
     {
         // Try establishing the connection to the server
         $this->checkConnection();
 
         // Send the build request to the server
-        if ( fwrite( $this->connection, $request = $this->buildRequest( $method, $path, $data, $headers ) ) === false )
-        {
+        if (fwrite($this->connection, $request = $this->buildRequest($method, $path, $data, $headers)) === false) {
             // Reestablish which seems to have been aborted
             //
             // The recursion in this method might be problematic if the
             // connection establishing mechanism does not correctly throw an
             // exception on failure.
             $this->connection = null;
-            return $this->request( $method, $path, $data, $raw );
+            return $this->request($method, $path, $data, $raw, $headers);
         }
 
         // Read server response headers
         $rawHeaders = '';
         $headers = array(
-            'connection' => ( $this->options['keep-alive'] ? 'Keep-Alive' : 'Close' ),
+            'connection' => ($this->options['keep-alive'] ? 'Keep-Alive' : 'Close'),
         );
 
         // Remove leading newlines, should not occur at all, actually.
-        while ( ( ( $line = fgets( $this->connection ) ) !== false ) &&
-                ( ( $lineContent = rtrim( $line ) ) === '' ) );
+        while((($line = fgets( $this->connection ) ) !== false) &&
+                (($lineContent = rtrim($line)) === ''));
 
         // Throw exception, if connection has been aborted by the server, and
         // leave handling to the user for now.
-        if ( $line === false )
-        {
+        if ($line === false) {
             // Reestablish which seems to have been aborted
             //
             // The recursion in this method might be problematic if the
@@ -204,7 +223,7 @@ class SocketClient extends AbstractHTTPClient
             // An aborted connection seems to happen here on long running
             // requests, which cause a connection timeout at server side.
             $this->connection = null;
-            return $this->request( $method, $path, $data, $raw );
+            return $this->request($method, $path, $data, $raw, $headers);
         }
 
         do {
@@ -212,89 +231,78 @@ class SocketClient extends AbstractHTTPClient
             $rawHeaders .= $lineContent . "\n";
 
             // Extract header values
-            if ( preg_match( '(^HTTP/(?P<version>\d+\.\d+)\s+(?P<status>\d+))S', $lineContent, $match ) )
-            {
+            if (preg_match( '(^HTTP/(?P<version>\d+\.\d+)\s+(?P<status>\d+))S', $lineContent, $match)) {
                 $headers['version'] = $match['version'];
                 $headers['status']  = (int) $match['status'];
+            } else {
+                list($key, $value) = explode(':', $lineContent, 2);
+                $headers[strtolower($key)] = ltrim($value);
             }
-            else
-            {
-                list( $key, $value ) = explode( ':', $lineContent, 2 );
-                $headers[strtolower( $key )] = ltrim( $value );
-            }
-        }  while ( ( ( $line = fgets( $this->connection ) ) !== false ) &&
-                   ( ( $lineContent = rtrim( $line ) ) !== '' ) );
+        }  while ((($line = fgets($this->connection)) !== false) &&
+                   (($lineContent = rtrim($line)) !== '' ));
 
         // Read response body
         $body = '';
-        if ( !isset( $headers['transfer-encoding'] ) ||
-             ( $headers['transfer-encoding'] !== 'chunked' ) )
-        {
+        if (!isset( $headers['transfer-encoding']) ||
+             ($headers['transfer-encoding'] !== 'chunked')) {
             // HTTP 1.1 supports chunked transfer encoding, if the according
             // header is not set, just read the specified amount of bytes.
-            $bytesToRead = (int) ( isset( $headers['content-length'] ) ? $headers['content-length'] : 0 );
+            $bytesToRead = (int) (isset($headers['content-length']) ? $headers['content-length'] : 0);
 
             // Read body only as specified by chunk sizes, everything else
             // are just footnotes, which are not relevant for us.
-            while ( $bytesToRead > 0 )
-            {
-                $body .= $read = fgets( $this->connection, $bytesToRead + 1 );
-                $bytesToRead -= strlen( $read );
+            while ($bytesToRead > 0) {
+                $body .= $read = fgets($this->connection, $bytesToRead + 1);
+                $bytesToRead -= strlen($read);
             }
-        }
-        else
-        {
+        } else {
             // When transfer-encoding=chunked has been specified in the
             // response headers, read all chunks and sum them up to the body,
             // until the server has finished. Ignore all additional HTTP
             // options after that.
             do {
-                $line = rtrim( fgets( $this->connection ) );
+                $line = rtrim(fgets($this->connection));
 
                 // Get bytes to read, with option appending comment
-                if ( preg_match( '(^([0-9a-f]+)(?:;.*)?$)', $line, $match ) )
+                if (preg_match('(^([0-9a-f]+)(?:;.*)?$)', $line, $match))
                 {
-                    $bytesToRead = hexdec( $match[1] );
+                    $bytesToRead = hexdec($match[1]);
 
                     // Read body only as specified by chunk sizes, everything else
                     // are just footnotes, which are not relevant for us.
                     $bytesLeft = $bytesToRead;
-                    while ( $bytesLeft > 0 )
-                    {
-                        $body .= $read = fread( $this->connection, $bytesLeft + 2 );
-                        $bytesLeft -= strlen( $read );
+                    while ($bytesLeft > 0) {
+                        $body .= $read = fread($this->connection, $bytesLeft + 2);
+                        $bytesLeft -= strlen($read);
                     }
                 }
-            } while ( $bytesToRead > 0 );
+            } while ($bytesToRead > 0);
 
             // Chop off \r\n from the end.
-            $body = substr( $body, 0, -2 );
+            $body = substr($body, 0, -2);
         }
 
         // Reset the connection if the server asks for it.
-        if ( $headers['connection'] !== 'Keep-Alive' )
-        {
-            fclose( $this->connection );
+        if ($headers['connection'] !== 'Keep-Alive') {
+            fclose($this->connection);
             $this->connection = null;
         }
 
         // Handle some response state as special cases
-        switch ( $headers['status'] )
-        {
+        switch ($headers['status']) {
             case 301:
             case 302:
             case 303:
             case 307:
-                $path = parse_url( $headers['location'], PHP_URL_PATH );
-                return $this->request( $method, $path, $data, $raw );
+                $path = parse_url($headers['location'], PHP_URL_PATH);
+                return $this->request($method, $path, $data, $raw, $headers);
         }
 
         // Create response object from couch db response
-        if ( $headers['status'] >= 400 )
-        {
-            return new ErrorResponse( $headers['status'], $headers, $body );
+        if ($headers['status'] >= 400) {
+            return new ErrorResponse($headers['status'], $headers, $body);
         }
-        return new Response( $headers['status'], $headers, $body, $raw );
+        return new Response($headers['status'], $headers, $body, $raw);
     }
 }
 

--- a/lib/Doctrine/CouchDB/HTTP/SocketClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/SocketClient.php
@@ -41,7 +41,9 @@ class SocketClient extends AbstractHTTPClient
 
     /**
      * Return the socket after setting up the connection to server and writing
-     * the headers.
+     * the headers. The returned resource can later be used to read and
+     * write data in chunks. These should be done without much delay as the
+     * connection might get closed.
      *
      * @return resource
      * @throws HTTPException
@@ -51,7 +53,7 @@ class SocketClient extends AbstractHTTPClient
         $method,
         $path,
         $data = null,
-        array$headers = array()
+        array $headers = array()
     ) {
         $this->checkConnection();
         $stringHeader = $this->buildRequest($method, $path, $data, $headers);

--- a/lib/Doctrine/CouchDB/HTTP/SocketClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/SocketClient.php
@@ -39,6 +39,12 @@ class SocketClient extends AbstractHTTPClient
      */
     protected $connection;
 
+    public function getConnection()
+    {
+        $this->checkConnection();
+        return $this->connection;
+    }
+
     /**
      * Check for server connection
      *
@@ -99,7 +105,7 @@ class SocketClient extends AbstractHTTPClient
      * @param array $headers
      * @return string
      */
-    protected function buildRequest( $method, $path, $data, $headers)
+    public function buildRequest( $method, $path, $data = null, array $headers = array())
     {
         // Create basic request headers
         $request = "$method $path HTTP/1.1\r\nHost: {$this->options['host']}\r\n";

--- a/lib/Doctrine/CouchDB/HTTP/StreamClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/StreamClient.php
@@ -33,6 +33,120 @@ namespace Doctrine\CouchDB\HTTP;
 class StreamClient extends AbstractHTTPClient
 {
     /**
+     * Connection pointer for connections, once keep alive is working on the
+     * CouchDb side.
+     *
+     * @var resource
+     */
+    protected $httpFilePointer;
+
+    /**
+     * Return the connection pointer after setting up the stream connection.
+     *
+     * @param string $method
+     * @param string $path
+     * @param string $data
+     * @param array $headers
+     * @return resource
+     * @throws HTTPException
+     */
+    public function getConnection($method, $path, $data, array $headers = array())
+    {
+        $this->checkConnection($method, $path, $data, $headers);
+        return $this->httpFilePointer;
+    }
+
+    /**
+     * Sets up the stream connection.
+     *
+     * @param $method
+     * @param $path
+     * @param $data
+     * @param $headers
+     * @throws HTTPException
+     */
+    protected function checkConnection($method, $path, $data, $headers)
+    {
+        $basicAuth = '';
+        if ( $this->options['username'] ) {
+            $basicAuth .= "{$this->options['username']}:{$this->options['password']}@";
+        }
+        if (!isset($headers['Content-Type'])) {
+            $headers['Content-Type'] = 'application/json';
+        }
+        $stringHeader = '';
+        if ($headers != null) {
+            foreach ($headers as $key => $val) {
+                $stringHeader .= $key . ": " . $val . "\r\n";
+            }
+        }
+        if ($this->httpFilePointer == null) {
+            // TODO SSL support?
+            $this->httpFilePointer = @fopen(
+                'http://' . $basicAuth . $this->options['host'] . ':' . $this->options['port'] . $path,
+                'r',
+                false,
+                stream_context_create(
+                    array(
+                        'http' => array(
+                            'method' => $method,
+                            'content' => $data,
+                            'ignore_errors' => true,
+                            'max_redirects' => 0,
+                            'user_agent' => 'Doctrine CouchDB ODM $Revision$',
+                            'timeout' => $this->options['timeout'],
+                            'header' => $stringHeader,
+                        ),
+                    )
+                )
+            );
+        }
+
+        // Check if connection has been established successfully.
+        if ( $this->httpFilePointer === false ) {
+            $error = error_get_last();
+            throw HTTPException::connectionFailure(
+                $this->options['ip'],
+                $this->options['port'],
+                $error['message'],
+                0
+            );
+        }
+    }
+
+    /**
+     * @param $connection
+     * @return array
+     */
+    public function getStreamHeaders($connection = null)
+    {
+        if ($connection == null) {
+            $connection = $this->httpFilePointer;
+        }
+        $headers = array();
+        if($connection !== false) {
+
+            $metaData = stream_get_meta_data($connection);
+            // The structure of this array differs depending on PHP compiled with
+            // --enable-curlwrappers or not. Both cases are normally required.
+            $rawHeaders = isset($metaData['wrapper_data']['headers'])
+                ? $metaData['wrapper_data']['headers'] : $metaData['wrapper_data'];
+
+            foreach ($rawHeaders as $lineContent) {
+                // Extract header values
+                if (preg_match('(^HTTP/(?P<version>\d+\.\d+)\s+(?P<status>\d+))S', $lineContent, $match)) {
+                    $headers['version'] = $match['version'];
+                    $headers['status'] = (int)$match['status'];
+                } else {
+                    list($key, $value) = explode(':', $lineContent, 2);
+                    $headers[strtolower($key)] = ltrim($value);
+                }
+            }
+        }
+        return $headers;
+    }
+
+    /**
      * Perform a request to the server and return the result
      *
      * Perform a request to the server and return the result converted into a
@@ -50,74 +164,16 @@ class StreamClient extends AbstractHTTPClient
      */
     public function request( $method, $path, $data = null, $raw = false, array $headers = array())
     {
-        $basicAuth = '';
-        if ( $this->options['username'] ) {
-            $basicAuth .= "{$this->options['username']}:{$this->options['password']}@";
-        }
-        if (!isset($headers['Content-Type'])) {
-            $headers['Content-Type'] = 'application/json';
-        }
-        $stringHeader = '';
-        if ($headers != null) {
-            foreach ($headers as $key => $val) {
-                $stringHeader .= $key . ": " . $val . "\r\n";
-            }
-        }
 
-        // TODO SSL support?
-        $httpFilePointer = @fopen(
-            'http://' . $basicAuth . $this->options['host']  . ':' . $this->options['port'] . $path,
-            'r',
-            false,
-            stream_context_create(
-                array(
-                    'http' => array(
-                        'method'        => $method,
-                        'content'       => $data,
-                        'ignore_errors' => true,
-                        'max_redirects' => 0,
-                        'user_agent'    => 'Doctrine CouchDB ODM $Revision$',
-                        'timeout'       => $this->options['timeout'],
-                        'header'        => $stringHeader,
-                    ),
-                )
-            )
-        );
+        $this->checkConnection($method, $path, $data, $headers);
 
-        // Check if connection has been established successfully
-        if ( $httpFilePointer === false ) {
-            $error = error_get_last();
-            throw HTTPException::connectionFailure(
-                $this->options['ip'],
-                $this->options['port'],
-                $error['message'],
-                0
-            );
-        }
-
-        // Read request body
+        // Read request body.
         $body = '';
-        while ( !feof( $httpFilePointer ) ) {
-            $body .= fgets( $httpFilePointer );
+        while ( !feof( $this->httpFilePointer ) ) {
+            $body .= fgets( $this->httpFilePointer );
         }
 
-        $metaData = stream_get_meta_data( $httpFilePointer );
-        // The structure of this array differs depending on PHP compiled with
-        // --enable-curlwrappers or not. Both cases are normally required.
-        $rawHeaders = isset( $metaData['wrapper_data']['headers'] )
-            ? $metaData['wrapper_data']['headers'] : $metaData['wrapper_data'];
-
-        $headers = array();
-        foreach ( $rawHeaders as $lineContent ) {
-            // Extract header values
-            if ( preg_match( '(^HTTP/(?P<version>\d+\.\d+)\s+(?P<status>\d+))S', $lineContent, $match ) ) {
-                $headers['version'] = $match['version'];
-                $headers['status']  = (int) $match['status'];
-            } else {
-                list( $key, $value ) = explode( ':', $lineContent, 2 );
-                $headers[strtolower( $key )] = ltrim( $value );
-            }
-        }
+        $headers = $this->getStreamHeaders();
 
         if ( empty($headers['status']) ) {
             throw HTTPException::readFailure(
@@ -128,7 +184,7 @@ class StreamClient extends AbstractHTTPClient
             );
         }
 
-        // Create response object from couch db response
+        // Create response object from couch db response.
         if ( $headers['status'] >= 400 )
         {
             return new ErrorResponse( $headers['status'], $headers, $body );

--- a/lib/Doctrine/CouchDB/HTTP/StreamClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/StreamClient.php
@@ -50,8 +50,12 @@ class StreamClient extends AbstractHTTPClient
      * @return resource
      * @throws HTTPException
      */
-    public function getConnection($method, $path, $data, array $headers = array())
-    {
+    public function getConnection(
+        $method,
+        $path,
+        $data = null,
+        array $headers = array()
+    ) {
         $this->checkConnection($method, $path, $data, $headers);
         return $this->httpFilePointer;
     }
@@ -68,7 +72,7 @@ class StreamClient extends AbstractHTTPClient
     protected function checkConnection($method, $path, $data, $headers)
     {
         $basicAuth = '';
-        if ( $this->options['username'] ) {
+        if ($this->options['username']) {
             $basicAuth .= "{$this->options['username']}:{$this->options['password']}@";
         }
         if (!isset($headers['Content-Type'])) {
@@ -103,7 +107,7 @@ class StreamClient extends AbstractHTTPClient
         }
 
         // Check if connection has been established successfully.
-        if ( $this->httpFilePointer === false ) {
+        if ($this->httpFilePointer === false) {
             $error = error_get_last();
             throw HTTPException::connectionFailure(
                 $this->options['ip'],
@@ -124,7 +128,7 @@ class StreamClient extends AbstractHTTPClient
             $connection = $this->httpFilePointer;
         }
         $headers = array();
-        if($connection !== false) {
+        if ($connection !== false) {
 
             $metaData = stream_get_meta_data($connection);
             // The structure of this array differs depending on PHP compiled with
@@ -162,20 +166,20 @@ class StreamClient extends AbstractHTTPClient
      * @return Response
      * @throws HTTPException
      */
-    public function request( $method, $path, $data = null, $raw = false, array $headers = array())
+    public function request($method, $path, $data = null, $raw = false, array $headers = array())
     {
 
         $this->checkConnection($method, $path, $data, $headers);
 
         // Read request body.
         $body = '';
-        while ( !feof( $this->httpFilePointer ) ) {
-            $body .= fgets( $this->httpFilePointer );
+        while (!feof( $this->httpFilePointer)) {
+            $body .= fgets($this->httpFilePointer);
         }
 
         $headers = $this->getStreamHeaders();
 
-        if ( empty($headers['status']) ) {
+        if (empty($headers['status'])) {
             throw HTTPException::readFailure(
                 $this->options['ip'],
                 $this->options['port'],
@@ -185,11 +189,11 @@ class StreamClient extends AbstractHTTPClient
         }
 
         // Create response object from couch db response.
-        if ( $headers['status'] >= 400 )
+        if ($headers['status'] >= 400)
         {
-            return new ErrorResponse( $headers['status'], $headers, $body );
+            return new ErrorResponse($headers['status'], $headers, $body);
         }
-        return new Response( $headers['status'], $headers, $body, $raw );
+        return new Response($headers['status'], $headers, $body, $raw);
     }
 
 }

--- a/lib/Doctrine/CouchDB/HTTP/StreamClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/StreamClient.php
@@ -42,6 +42,7 @@ class StreamClient extends AbstractHTTPClient
 
     /**
      * Return the connection pointer after setting up the stream connection.
+     * The returned resource can later be used to read data in chunks.
      *
      * @param string $method
      * @param string $path

--- a/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
@@ -488,19 +488,20 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
     public function testGetChangesAsStream()
     {
         $client = $this->couchClient;
+        // Recreate DB
+        $client->deleteDatabase($this->getTestDatabase());
+        $client->createDatabase($this->getTestDatabase());
+
         // Stream of changes feed.
         $stream = $client->getChangesAsStream();
-
         list($id, $rev) = $client->postDocument(array("_id" => "stream1", "foo" => "bar"));
         // Get the change feed data for stream1.
         while(trim($line = fgets($stream)) == '');
         $this->assertEquals("stream1", json_decode($line, true)["id"]);
-
         list($id, $rev) = $client->postDocument(array("_id" => "stream2", "foo" => "bar"));
         // Get the change feed data for stream2.
         while(trim($line = fgets($stream)) == '');
         $this->assertEquals("stream2", json_decode($line, true)["id"]);
-
         fclose($stream);
     }
 }

--- a/tests/Doctrine/Tests/CouchDB/Functional/HTTP/MultipartParserAndSenderTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/HTTP/MultipartParserAndSenderTest.php
@@ -1,0 +1,322 @@
+<?php
+
+namespace Doctrine\Tests\CouchDB\Functional\HTTP;
+
+
+use Doctrine\CouchDB\CouchDBClient;
+use Doctrine\CouchDB\HTTP\ErrorResponse;
+use Doctrine\CouchDB\HTTP\MultipartParserAndSender;
+use Doctrine\CouchDB\HTTP\StreamClient;
+
+class MultipartParserAndSenderTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCase
+{
+    protected $parserAndSender;
+    protected $sourceMethod;
+    protected $sourcePath;
+    protected $sourceParams;
+    protected $targetPath;
+    protected $sourceHeaders;
+    protected $docId;
+    protected $streamClientMock;
+
+    public function setUp()
+    {
+        // Use mocked StreamClient to generate desired source data stream for
+        // testing.
+        $this->streamClientMock = $this->getMockBuilder(
+            'Doctrine\CouchDB\HTTP\StreamClient'
+        )->disableOriginalConstructor()->getMock();
+
+        $this->parserAndSender = new MultipartParserAndSender(
+            $this->getHttpClient(),
+            $this->getHttpClient()
+        );
+        // Set the protected $sourceClient of parserAndSender to the
+        // streamClientMock.
+        $reflector = new \ReflectionProperty(
+            'Doctrine\CouchDB\HTTP\MultipartParserAndSender',
+            'sourceClient'
+        );
+        $reflector->setAccessible(true);
+        $reflector->setValue($this->parserAndSender, $this->streamClientMock);
+
+        // Params for the request.
+        $this->sourceParams = array('revs' => true, 'latest' => true);
+        $this->sourceMethod = 'GET';
+        $this->docId = 'multipartTestDoc';
+        $this->sourcePath = '/' . $this->getTestDatabase() . '/' . $this->docId;
+        $this->targetPath = '/' .$this->getTestDatabase() . '_multipart_copy'
+            . '/' . $this->docId . '?new_edits=false';
+        $this->sourceHeaders = array('Accept' => 'multipart/mixed');
+
+
+    }
+
+    public function testRequestThrowsHTTPExceptionOnEmptyStatus()
+    {
+        $this->setExpectedException(
+            '\Doctrine\CouchDB\HTTP\HTTPException',
+            sprintf(
+                "Could read from server at %s:%d: '%d: %s'",
+                '127.0.0.1',
+                '5984',
+                0,
+                'Received an empty response or not status code'
+            )
+
+        );
+        // Return header without status code.
+        $this->streamClientMock->expects($this->once())
+            ->method('getStreamHeaders')
+            ->willReturn(array());
+
+        $this->streamClientMock->expects($this->exactly(2))
+            ->method('getOptions')
+            ->will($this->onConsecutiveCalls(
+                array('ip' => '127.0.0.1'),
+                array('port' => '5984')
+            ));
+
+        $this->parserAndSender->request(
+            $this->sourceMethod,
+            $this->sourcePath,
+            $this->targetPath,
+            null,
+            $this->sourceHeaders
+        );
+    }
+
+    public function testRequestReturnsErrorResponseOnWrongStatusCode()
+    {
+        // Return header without status code > 400.
+        $this->streamClientMock->expects($this->once())
+            ->method('getStreamHeaders')
+            ->willReturn(array('status' => 404));
+
+        $string = 'This is the sample body of the response from the source.\n
+         It has two lines.';
+        $stream = fopen('data://text/plain,' . $string,'r');
+        $this->streamClientMock->expects($this->once())
+            ->method('getConnection')
+            ->willReturn($stream);
+
+        $response = $this->parserAndSender->request(
+            $this->sourceMethod,
+            $this->sourcePath,
+            $this->targetPath,
+            null,
+            $this->sourceHeaders
+        );
+
+        $this->AssertEquals(
+            new ErrorResponse(
+                '404',
+                array('status' => 404),
+                $string
+            ),
+            $response
+        );
+
+    }
+
+    /**
+     * @expectedException \UnexpectedValueException
+     * @expectedExceptionMessage This value is not supported.
+     */
+    public function testRequestThrowsExceptionOnUnsupportedContentType()
+    {
+        // Return header with status code as 200.
+        $this->streamClientMock->expects($this->once())
+            ->method('getStreamHeaders')
+            ->willReturn(array('status' => 200));
+        $string = <<<EOT
+--7b1596fc4940bc1be725ad67f11ec1c4
+Content-Type: HTML
+EOT;
+        $stream = fopen('data://text/plain,' . $string,'r');
+        $this->streamClientMock->expects($this->once())
+            ->method('getConnection')
+            ->willReturn($stream);
+
+        $response = $this->parserAndSender->request(
+            $this->sourceMethod,
+            $this->sourcePath,
+            $this->targetPath,
+            null,
+            $this->sourceHeaders
+        );
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Unknown parameter with Content-Type.
+     */
+    public function testRequestThrowsExceptionOnUnknownParamWithContentType()
+    {
+        // Return header with status code as 200.
+        $this->streamClientMock->expects($this->once())
+            ->method('getStreamHeaders')
+            ->willReturn(array('status' => 200));
+        $string = <<<EOT
+--7b1596fc4940bc1be725ad67f11ec1c4
+Content-Type: application/json; unknownBlahBlah="true"
+EOT;
+        $stream = fopen('data://text/plain,' . $string,'r');
+        $this->streamClientMock->expects($this->once())
+            ->method('getConnection')
+            ->willReturn($stream);
+
+        $response = $this->parserAndSender->request(
+            $this->sourceMethod,
+            $this->sourcePath,
+            $this->targetPath,
+            null,
+            $this->sourceHeaders
+        );
+    }
+
+    public function testRequestSuccessWithoutAttachment()
+    {
+        // Return header with status code as 200.
+        $this->streamClientMock->expects($this->once())
+            ->method('getStreamHeaders')
+            ->willReturn(array('status' => 200));
+        $docs = array(
+            '{"_id": "' .$this->docId. '","_rev": "1-abc","foo":"bar"}',
+            '{"_id": "' .$this->docId. '","_rev": "1-abcd","foo":"baz"}',
+            '{"_id": "' .$this->docId. '","_rev": "1-abcde","foo":"baz"}',
+        );
+        $string = <<<EOT
+--7b1596fc4940bc1be725ad67f11ec1c4
+Content-Type: application/json
+
+$docs[0]
+--7b1596fc4940bc1be725ad67f11ec1c4
+Content-Type: application/json
+
+$docs[1]
+--7b1596fc4940bc1be725ad67f11ec1c4
+Content-Type: application/json; error="true"
+
+{"missing":"3-6bcedf1"}
+--7b1596fc4940bc1be725ad67f11ec1c4--
+Content-Type: application/json
+
+$docs[2]
+--7b1596fc4940bc1be725ad67f11ec1c4
+EOT;
+        $stream = fopen('data://text/plain,' . $string,'r');
+        $this->streamClientMock->expects($this->once())
+            ->method('getConnection')
+            ->willReturn($stream);
+
+        $response = $this->parserAndSender->request(
+            $this->sourceMethod,
+            $this->sourcePath,
+            $this->targetPath,
+            null,
+            $this->sourceHeaders
+        );
+        // The returned response should have the JSON docs. The missing
+        // revision at the source will be skipped.
+        $this->AssertEquals(2, count($response));
+        $this->AssertEquals(3, count($response[0]));
+        $this->AssertEquals($docs[0], $response[0][0]);
+        $this->AssertEquals($docs[1], $response[0][1]);
+        $this->AssertEquals($docs[2], $response[0][2]);
+    }
+
+    public function testRequestSuccessWithAttachments()
+    {
+        $client = new CouchDBClient(
+            $this->getHttpClient(),
+            $this->getTestDatabase()
+        );
+        // Recreate DB
+        $client->deleteDatabase($this->getTestDatabase());
+        $client->createDatabase($this->getTestDatabase());
+
+        // Doc id.
+        $id = $this->docId;
+        // Document with attachments.
+        $docWithAttachment = array (
+            '_id' => $id,
+            '_rev' => '1-abc',
+            '_attachments' =>
+                array (
+                    'foo.txt' =>
+                        array (
+                            'content_type' => 'text/plain',
+                            'data' => 'VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ=',
+                        ),
+                    'bar.txt' =>
+                        array (
+                            'content_type' => 'text/plain',
+                            'data' => 'VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ=',
+                        ),
+                ),
+        );
+        // Doc without any attachment. The id of both the docs is same.
+        // So we will get two leaf revisions.
+        $doc = array('_id' => $id, 'foo' => 'bar', '_rev' => '1-bcd');
+
+        // Add the documents to the test db using Bulk API.
+        $updater = $client->createBulkUpdater();
+        $updater->updateDocument($docWithAttachment);
+        $updater->updateDocument($doc);
+        // Set newedits to false to use the supplied _rev instead of assigning
+        // new ones.
+        $updater->setNewEdits(false);
+        $response = $updater->execute();
+
+        // Create the copy database and a copyClient to interact with it.
+        $copyDb = $this->getTestDatabase() . '_multipart_copy';
+        $client->createDatabase($copyDb);
+        $copyClient = new CouchDBClient($client->getHttpClient(), $copyDb);
+
+        // Missing revisions in the $copyDb.
+        $missingRevs = array('1-abc', '1-bcd');
+        $this->sourceParams['open_revs'] = json_encode($missingRevs);
+        $query = http_build_query($this->sourceParams);
+        $this->sourcePath .= '?' . $query;
+
+        // Get the multipart data stream from real CouchDB instance.
+        $stream = (new StreamClient())->getConnection(
+            $this->sourceMethod,
+            $this->sourcePath,
+            null,
+            $this->sourceHeaders
+        );
+
+        // Set the return values for the mocked StreamClient.
+        $this->streamClientMock->expects($this->once())
+            ->method('getConnection')
+            ->willReturn($stream);
+        // Return header with status code as 200.
+        $this->streamClientMock->expects($this->once())
+            ->method('getStreamHeaders')
+            ->willReturn(array('status' => 200));
+
+        // Transfer the missing revisions from the source to the target.
+        list($docStack, $responses) = $this->parserAndSender->request(
+            $this->sourceMethod,
+            $this->sourcePath,
+            $this->targetPath,
+            null,
+            $this->sourceHeaders
+
+        );
+        // $docStack should contain the doc that didn't have the attachment.
+        $this->assertEquals(1, count($docStack));
+        $this->assertEquals($doc, json_decode($docStack[0], true));
+
+        // The doc with attachment should have been copied to the copyDb.
+        $this->assertEquals(1, count($responses));
+        $this->assertArrayHasKey('ok', $responses[0]);
+        $this->assertEquals(true, $responses[0]['ok']);
+        // Clean up.
+        $client->deleteDatabase($this->getTestDatabase());
+        $client->createDatabase($this->getTestDatabase());
+        $client->deleteDatabase($copyDb);
+    }
+}


### PR DESCRIPTION
Hi. I am working on a project under Google's summer of code program for Drupal which involves writing a PHP based replicator. This is the second set of changes enchancing the client in general and also for supporting the PHP implementation of the CouchDB replication protocol. The first set of changes have already been merged and can be seen by following [pull/42](https://github.com/doctrine/couchdb-client/pull/42) link.

The changes mainly now allow the client to read data from source CouchDb client in chunks and stream it to the target CouchDb client. This is mainly useful when the docs to be replicated have large attachments exceeding the space available locally on the drive. To do this I have added the ability in the StreamClient and the SocketClient to return the connection resource.

Let's go through the changes file by file:

1. **CouchDBClient.php**
    1. Add `transferChangedDocuments()`. This method transfers the missing revisions from the current source database to the target database.
    2. Add `getChangesAsStream()`. This method returns the resource from which changes feed can be read continuously.

2. **AbstractHTTPClient.php**
    1. Add `getOptions()`. It's the getter for connection options.

3. **Client.php**
    1. Add `getConnection()`. This method is expected to return a connection resource which can be used to read or write in small chunks.

4. **MultipartParserAndSender.php**
    This file has all the logic needed to transfer the multipart data between two connection resources. It reads the multipart stream, parses it, and streams it to the target. For details see the inline documentations.

5. **SocketClient.php**
    1. The code has been modularized.
    2. Add `getConnection()`. This method returns the connection resource after setting up the connection. This resource can be used for reading or writing data in chunks. This must be done without much delay as the connection might get closed.

6. **StreamClient.php**
    1. The code has been modularized.
    2. Add `getConnection()`. This method returns the connection resource after setting up the connection. This resource can be used **only for reading** data in chunks.
7. **CouchDBClientTest.php**
    1. Add `testTransferChangedDocuments()`. This is the test for `transferChangedDocuments()`.
    2. Add `testGetChangesAsStream()`. This is the test for `getChangesAsStream()`.

8. **Other Changes**
    1. The inline comments have been made to lie within the 80 chars on a line limit.
    2. The newly added or modified code has been made to follow PSR-2 conventions. This mostly includes removal of spaces betweent the opening/closing parentheses and the first/last parameter and the placement of the curly brace on the same line for `if`, `for`, `while` etc. 
