### PR TITLE
Add ensureFullCommit() method with test. Add findRevisions() method to fetch the docs of all or the specified revisions only. Add testFindRevisions().

### DIFF
--- a/lib/Doctrine/CouchDB/CouchDBClient.php
+++ b/lib/Doctrine/CouchDB/CouchDBClient.php
@@ -143,15 +143,39 @@ class CouchDBClient
     }
 
     /**
-     * Find a document by ID and return the HTTP response.
+     * Find a document by ID and return the HTTP response. If
+     * $getAllLeafRevisions is true, documents for all leaf revisions are
+     * retrieved and $revisions parameter is ignored. If $getAllLeafRevisions
+     * is false and $revisions is not null, only the specified leaf revisions
+     * are retrieved.
      *
-     * @param  string $id
+     * @param string $id
+     * @param bool $getAllLeafRevisions
+     * @param array $revisions
      * @return HTTP\Response
      */
-    public function findDocument($id)
-    {
-        $documentPath = '/' . $this->databaseName . '/' . urlencode($id);
-        return $this->httpClient->request( 'GET', $documentPath );
+    public function findDocument(
+        $id,
+        $getAllLeafRevisions = false,
+        array $revisions = null
+    ) {
+        $path = '/' . $this->databaseName . '/' . urlencode($id);
+        if ($getAllLeafRevisions == true) {
+            // Fetch documents of all leaf revisions.
+            $path .= '?open_revs=all';
+        } else if ($revisions != null) {
+            // Fetch documents of only specified leaf revisions.
+            $path .= '?open_revs=' . json_encode($revisions);
+        }
+        // Set the Accept header to application/json to get array as response.
+        // Without this the response is multipart/mixed stream.
+        return $this->httpClient->request(
+            'GET',
+            $path,
+            null,
+            false,
+            array('Accept' => 'application/json')
+        );
     }
 
     /**

--- a/lib/Doctrine/CouchDB/CouchDBClient.php
+++ b/lib/Doctrine/CouchDB/CouchDBClient.php
@@ -20,6 +20,7 @@
 namespace Doctrine\CouchDB;
 
 use Doctrine\CouchDB\HTTP\Client;
+use Doctrine\CouchDB\HTTP\Response;
 use Doctrine\CouchDB\HTTP\HTTPException;
 use Doctrine\CouchDB\HTTP\MultipartParserAndSender;
 use Doctrine\CouchDB\HTTP\StreamClient;
@@ -143,32 +144,33 @@ class CouchDBClient
     }
 
     /**
-     * Find a document by ID and return the HTTP response. If
-     * $getAllLeafRevisions is true, documents for all leaf revisions are
-     * retrieved and $revisions parameter is ignored. If $getAllLeafRevisions
+     * Find a document by ID and return the HTTP response.
+     *
+     * If $allOpenRevs is true, documents for all leaf revisions are
+     * retrieved and $revisions parameter is ignored. If $allOpenRevs
      * is false and $revisions is not null, only the specified leaf revisions
      * are retrieved.
      *
      * @param string $id
-     * @param bool $getAllLeafRevisions
+     * @param bool $allOpenRevs
      * @param array $revisions
      * @return HTTP\Response
      */
     public function findDocument(
         $id,
-        $getAllLeafRevisions = false,
+        $allOpenRevs = false,
         array $revisions = null
     ) {
         $path = '/' . $this->databaseName . '/' . urlencode($id);
-        if ($getAllLeafRevisions == true) {
+        if ($allOpenRevs == true) {
             // Fetch documents of all leaf revisions.
             $path .= '?open_revs=all';
         } else if ($revisions != null) {
-            // Fetch documents of only specified leaf revisions.
+            // Fetch documents of only the specified leaf revisions.
             $path .= '?open_revs=' . json_encode($revisions);
         }
-        // Set the Accept header to application/json to get array as response.
-        // Without this the response is multipart/mixed stream.
+        // Set the Accept header to application/json to get JSON array in the
+        // response's body. Without this the response is multipart/mixed stream.
         return $this->httpClient->request(
             'GET',
             $path,

--- a/lib/Doctrine/CouchDB/CouchDBClient.php
+++ b/lib/Doctrine/CouchDB/CouchDBClient.php
@@ -658,4 +658,20 @@ class CouchDBClient
         return $stream;
 
     }
+
+    /**
+     * Commit any recent changes to the specified database to disk.
+     *
+     * @return array
+     * @throws HTTPException
+     */
+    public function ensureFullCommit()
+    {
+        $path = '/' . $this->databaseName . '/_ensure_full_commit';
+        $response = $this->httpClient->request('POST', $path);
+        if ($response->status != 201) {
+            throw HTTPException::fromResponse($path, $response);
+        }
+        return $response->body;
+    }
 }

--- a/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
@@ -254,7 +254,7 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
     {
         $client = $this->couchClient;
 
-        // Recreate DB
+        // Recreate DB.
         $client->deleteDatabase($this->getTestDatabase());
         $client->createDatabase($this->getTestDatabase());
         // Test fetching of document.

--- a/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
@@ -1,7 +1,6 @@
 <?php
 
 namespace Doctrine\Tests\CouchDB\Functional;
-
 use Doctrine\CouchDB\CouchDBClient;
 use Doctrine\CouchDB\View\FolderDesignDocument;
 
@@ -246,6 +245,68 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
         $result = $query->execute();
 
         $client->compactView('test-design-doc-query');
+    }
+
+    /**
+     * @depends testCreateBulkUpdater
+     */
+    public function testFindDocument()
+    {
+        $client = $this->couchClient;
+
+        // Recreate DB
+        $client->deleteDatabase($this->getTestDatabase());
+        $client->createDatabase($this->getTestDatabase());
+        // Test fetching of document.
+        list($id, $rev) = $client->postDocument(array('foo' => 'bar'));
+        $response = $client->findDocument($id);
+        $this->assertInstanceOf('\Doctrine\CouchDB\HTTP\Response', $response);
+        $this->assertObjectHasAttribute('body', $response);
+        $body = $response->body;
+        $this->assertEquals(
+            array('_id' => $id, '_rev' => $rev, 'foo' => 'bar'),
+            $body
+        );
+
+        // Test fetching of documents of all revisions. The _id of all the
+        // documents is same. So we will get multiple leaf revisions.
+        $id = 'multiple_revisions';
+        $docs = array(
+            array('_id' => $id, 'foo' => 'bar1', '_rev' => '1-abc'),
+            array('_id' => $id, 'foo' => 'bar2', '_rev' => '1-bcd'),
+            array('_id' => $id, 'foo' => 'bar3', '_rev' => '1-cde')
+        );
+
+        // Add the documents to the test db using Bulk API.
+        $updater = $this->couchClient->createBulkUpdater();
+        $updater->updateDocuments($docs);
+        // Set newedits to false to use the supplied _rev instead of assigning
+        // new ones.
+        $updater->setNewEdits(false);
+        $response = $updater->execute();
+        // The third param should be ignored as all revisions are being fetched.
+        $response = $client->findDocument($id, true, array('3-ghfgf'));
+        $expected = array(
+            array('ok' => $docs[2]),
+            array('ok' => $docs[1]),
+            array('ok' => $docs[0])
+        );
+        $this->assertEquals($expected, $response->body);
+        // Test fetching of specific revisions.
+        $response = $client->findDocument(
+            $id,
+            false,
+            array('1-abc', '1-cde', '100-ghfgf', '200-blah')
+        );
+        $body = $response->body;
+        $this->assertEquals(4, count($body));
+        // Doc with _rev = 1-cde.
+        $this->assertEquals($docs[2], $body[0]['ok']);
+        // Doc with _rev = 1-abc.
+        $this->assertEquals($docs[0], $body[1]['ok']);
+        // Missing revisions.
+        $this->assertEquals(array('missing' => '100-ghfgf'), $body[2]);
+        $this->assertEquals(array('missing' => '200-blah'), $body[3]);
     }
 
     public function testFindDocuments()

--- a/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
@@ -510,4 +510,13 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
         $this->assertEquals("stream2", json_decode($line, true)["id"]);
         fclose($stream);
     }
+
+    public function testEnsureFullCommit()
+    {
+        $client = $this->couchClient;
+        $body = $client->ensureFullCommit();
+        $this->assertArrayHasKey('instance_start_time', $body);
+        $this->assertArrayHasKey('ok', $body);
+        $this->assertEquals(true, $body['ok']);
+    }
 }


### PR DESCRIPTION
Hi. I am working on a project under Google's summer of code program for Drupal which involves writing a PHP based replicator. This is the third set of changes enchancing the client in general and also for supporting the PHP implementation of the CouchDB replication protocol. The first and second set of changes have already been merged and can be seen by following [pull/42](https://github.com/doctrine/couchdb-client/pull/42)  and  [pull/45](https://github.com/doctrine/couchdb-client/pull/45) links.

The changes include:

1. **CouchDBClient.php**
    1. Add `findRevisions` to support retrieval of documents of either all or the specified revisions.
    2. Add `ensureFullCommit()`. This ensures that any recent changes to the database get committed to the disk.
2. **CouchDBClientTest.php**
    1. Add `testFindDocument()`. This is the test for `findDocument()`.
    2. Add `testFindRevisions()` as the test for `findRevisions()` method.
    2. Add `testEnsureFullCommit()`. This is the test for `ensureFullCommit()`.

