### PR TITLE
Adding a path option for prefixed databases

### DIFF
--- a/lib/Doctrine/CouchDB/CouchDBClient.php
+++ b/lib/Doctrine/CouchDB/CouchDBClient.php
@@ -81,7 +81,7 @@ class CouchDBClient
             throw new \InvalidArgumentException("'dbname' is a required option to create a CouchDBClient");
         }
 
-        $defaults = array('type' => 'socket', 'host' => 'localhost', 'port' => 5984, 'user' => null, 'password' => null, 'ip' => null, 'logging' => false);
+        $defaults = array('type' => 'socket', 'host' => 'localhost', 'port' => 5984, 'user' => null, 'password' => null, 'ip' => null, 'ssl' => false, 'path' => null, 'logging' => false );
         $options = array_merge($defaults, $options);
 
         if (!isset(self::$clients[$options['type']])) {
@@ -90,7 +90,7 @@ class CouchDBClient
             ));
         }
         $connectionClass = self::$clients[$options['type']];
-        $connection = new $connectionClass($options['host'], $options['port'], $options['user'], $options['password'], $options['ip']);
+        $connection = new $connectionClass($options['host'], $options['port'], $options['user'], $options['password'], $options['ip'], $options['ssl'], $options['path']);
         if ($options['logging'] === true) {
             $connection = new HTTP\LoggingClient($connection);
         }

--- a/lib/Doctrine/CouchDB/CouchDBClient.php
+++ b/lib/Doctrine/CouchDB/CouchDBClient.php
@@ -671,7 +671,8 @@ class CouchDBClient
             $connectionOptions['username'],
             $connectionOptions['password'],
             $connectionOptions['ip'],
-            $connectionOptions['ssl']
+            $connectionOptions['ssl'],
+            $connectionOptions['path']
         );
 
         foreach ($params as $key => $value) {

--- a/lib/Doctrine/CouchDB/HTTP/AbstractHTTPClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/AbstractHTTPClient.php
@@ -29,6 +29,7 @@ abstract class AbstractHTTPClient implements Client
         'keep-alive' => true,
         'username'   => null,
         'password'   => null,
+        'path'       => null,
     );
 
     /**
@@ -43,15 +44,17 @@ abstract class AbstractHTTPClient implements Client
      * @param string $password
      * @param string $ip
      * @param bool $ssl
+     * @param string $path
      * @return \Doctrine\CouchDB\HTTP\AbstractHTTPClient
      */
-    public function __construct( $host = 'localhost', $port = 5984, $username = null, $password = null, $ip = null , $ssl = false )
+    public function __construct( $host = 'localhost', $port = 5984, $username = null, $password = null, $ip = null , $ssl = false, $path = null )
     {
         $this->options['host']     = (string) $host;
         $this->options['port']     = (int) $port;
         $this->options['ssl']      = $ssl;
         $this->options['username'] = $username;
         $this->options['password'] = $password;
+        $this->options['path'] = $path;
 
         if ($ip === null) {
             $this->options['ip'] = gethostbyname($this->options['host']);

--- a/lib/Doctrine/CouchDB/HTTP/AbstractHTTPClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/AbstractHTTPClient.php
@@ -54,7 +54,7 @@ abstract class AbstractHTTPClient implements Client
         $this->options['ssl']      = $ssl;
         $this->options['username'] = $username;
         $this->options['password'] = $password;
-        $this->options['path'] = $path;
+        $this->options['path']     = $path;
 
         if ($ip === null) {
             $this->options['ip'] = gethostbyname($this->options['host']);

--- a/lib/Doctrine/CouchDB/HTTP/MultipartParserAndSender.php
+++ b/lib/Doctrine/CouchDB/HTTP/MultipartParserAndSender.php
@@ -48,7 +48,8 @@ class MultipartParserAndSender
             $sourceOptions['username'],
             $sourceOptions['password'],
             $sourceOptions['ip'],
-            $sourceOptions['ssl']
+            $sourceOptions['ssl'],
+            $sourceOptions['path']
         );
 
         $targetOptions = $target->getOptions();
@@ -58,7 +59,8 @@ class MultipartParserAndSender
             $targetOptions['username'],
             $targetOptions['password'],
             $targetOptions['ip'],
-            $targetOptions['ssl']
+            $targetOptions['ssl'],
+            $sourceOptions['path']
         );
     }
 

--- a/lib/Doctrine/CouchDB/HTTP/SocketClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/SocketClient.php
@@ -189,6 +189,10 @@ class SocketClient extends AbstractHTTPClient
      */
     public function request($method, $path, $data = null, $raw = false, array $headers = array())
     {
+        if ($this->options['path']) {
+            $path = '/' . $this->options['path'] . $path;
+        }
+
         // Try establishing the connection to the server
         $this->checkConnection();
 

--- a/lib/Doctrine/CouchDB/HTTP/SocketClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/SocketClient.php
@@ -189,11 +189,9 @@ class SocketClient extends AbstractHTTPClient
      */
     public function request($method, $path, $data = null, $raw = false, array $headers = array())
     {
+        $full_path = $path;
         if ($this->options['path']) {
             $full_path = '/' . $this->options['path'] . $path;
-        }
-        else {
-            $full_path = $path;
         }
 
         // Try establishing the connection to the server

--- a/lib/Doctrine/CouchDB/HTTP/SocketClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/SocketClient.php
@@ -190,14 +190,14 @@ class SocketClient extends AbstractHTTPClient
     public function request($method, $path, $data = null, $raw = false, array $headers = array())
     {
         if ($this->options['path']) {
-            $path = '/' . $this->options['path'] . $path;
+            $full_path = '/' . $this->options['path'] . $path;
         }
 
         // Try establishing the connection to the server
         $this->checkConnection();
 
         // Send the build request to the server
-        if (fwrite($this->connection, $request = $this->buildRequest($method, $path, $data, $headers)) === false) {
+        if (fwrite($this->connection, $request = $this->buildRequest($method, $full_path, $data, $headers)) === false) {
             // Reestablish which seems to have been aborted
             //
             // The recursion in this method might be problematic if the

--- a/lib/Doctrine/CouchDB/HTTP/SocketClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/SocketClient.php
@@ -55,8 +55,13 @@ class SocketClient extends AbstractHTTPClient
         $data = null,
         array $headers = array()
     ) {
+        $full_path = $path;
+        if ($this->options['path']) {
+            $full_path = '/' . $this->options['path'] . $path;
+        }
+
         $this->checkConnection();
-        $stringHeader = $this->buildRequest($method, $path, $data, $headers);
+        $stringHeader = $this->buildRequest($method, $full_path, $data, $headers);
         // Send the build request to the server
         if (fwrite($this->connection, $stringHeader) === false) {
             // Reestablish which seems to have been aborted

--- a/lib/Doctrine/CouchDB/HTTP/SocketClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/SocketClient.php
@@ -192,6 +192,9 @@ class SocketClient extends AbstractHTTPClient
         if ($this->options['path']) {
             $full_path = '/' . $this->options['path'] . $path;
         }
+        else {
+            $full_path = $path;
+        }
 
         // Try establishing the connection to the server
         $this->checkConnection();

--- a/lib/Doctrine/CouchDB/HTTP/SocketClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/SocketClient.php
@@ -55,13 +55,13 @@ class SocketClient extends AbstractHTTPClient
         $data = null,
         array $headers = array()
     ) {
-        $full_path = $path;
+        $fullPath = $path;
         if ($this->options['path']) {
-            $full_path = '/' . $this->options['path'] . $path;
+            $fullPath = '/' . $this->options['path'] . $path;
         }
 
         $this->checkConnection();
-        $stringHeader = $this->buildRequest($method, $full_path, $data, $headers);
+        $stringHeader = $this->buildRequest($method, $fullPath, $data, $headers);
         // Send the build request to the server
         if (fwrite($this->connection, $stringHeader) === false) {
             // Reestablish which seems to have been aborted
@@ -194,16 +194,16 @@ class SocketClient extends AbstractHTTPClient
      */
     public function request($method, $path, $data = null, $raw = false, array $headers = array())
     {
-        $full_path = $path;
+        $fullPath = $path;
         if ($this->options['path']) {
-            $full_path = '/' . $this->options['path'] . $path;
+            $fullPath = '/' . $this->options['path'] . $path;
         }
 
         // Try establishing the connection to the server
         $this->checkConnection();
 
         // Send the build request to the server
-        if (fwrite($this->connection, $request = $this->buildRequest($method, $full_path, $data, $headers)) === false) {
+        if (fwrite($this->connection, $request = $this->buildRequest($method, $fullPath, $data, $headers)) === false) {
             // Reestablish which seems to have been aborted
             //
             // The recursion in this method might be problematic if the

--- a/lib/Doctrine/CouchDB/HTTP/StreamClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/StreamClient.php
@@ -169,6 +169,9 @@ class StreamClient extends AbstractHTTPClient
      */
     public function request($method, $path, $data = null, $raw = false, array $headers = array())
     {
+        if ($this->options['path']) {
+            $path = '/' . $this->options['path'] . $path;
+        }
 
         $this->checkConnection($method, $path, $data, $headers);
 

--- a/lib/Doctrine/CouchDB/HTTP/StreamClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/StreamClient.php
@@ -60,6 +60,9 @@ class StreamClient extends AbstractHTTPClient
         if ($this->options['path']) {
             $full_path = '/' . $this->options['path'] . $path;
         }
+        else {
+            $full_path = $path;
+        }
 
         $this->checkConnection($method, $full_path, $data, $headers);
         return $this->httpFilePointer;
@@ -175,6 +178,9 @@ class StreamClient extends AbstractHTTPClient
     {
         if ($this->options['path']) {
             $full_path = '/' . $this->options['path'] . $path;
+        }
+        else {
+            $full_path = $path;
         }
 
         $this->checkConnection($method, $full_path, $data, $headers);

--- a/lib/Doctrine/CouchDB/HTTP/StreamClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/StreamClient.php
@@ -57,12 +57,12 @@ class StreamClient extends AbstractHTTPClient
         $data = null,
         array $headers = array()
     ) {
-        $full_path = $path;
+        $fullPath = $path;
         if ($this->options['path']) {
-            $full_path = '/' . $this->options['path'] . $path;
+            $fullPath = '/' . $this->options['path'] . $path;
         }
 
-        $this->checkConnection($method, $full_path, $data, $headers);
+        $this->checkConnection($method, $fullPath, $data, $headers);
         return $this->httpFilePointer;
     }
 
@@ -174,12 +174,12 @@ class StreamClient extends AbstractHTTPClient
      */
     public function request($method, $path, $data = null, $raw = false, array $headers = array())
     {
-        $full_path = $path;
+        $fullPath = $path;
         if ($this->options['path']) {
-            $full_path = '/' . $this->options['path'] . $path;
+            $fullPath = '/' . $this->options['path'] . $path;
         }
 
-        $this->checkConnection($method, $full_path, $data, $headers);
+        $this->checkConnection($method, $fullPath, $data, $headers);
 
         // Read request body.
         $body = '';

--- a/lib/Doctrine/CouchDB/HTTP/StreamClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/StreamClient.php
@@ -57,11 +57,9 @@ class StreamClient extends AbstractHTTPClient
         $data = null,
         array $headers = array()
     ) {
+        $full_path = $path;
         if ($this->options['path']) {
             $full_path = '/' . $this->options['path'] . $path;
-        }
-        else {
-            $full_path = $path;
         }
 
         $this->checkConnection($method, $full_path, $data, $headers);
@@ -176,11 +174,9 @@ class StreamClient extends AbstractHTTPClient
      */
     public function request($method, $path, $data = null, $raw = false, array $headers = array())
     {
+        $full_path = $path;
         if ($this->options['path']) {
             $full_path = '/' . $this->options['path'] . $path;
-        }
-        else {
-            $full_path = $path;
         }
 
         $this->checkConnection($method, $full_path, $data, $headers);

--- a/lib/Doctrine/CouchDB/HTTP/StreamClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/StreamClient.php
@@ -57,7 +57,11 @@ class StreamClient extends AbstractHTTPClient
         $data = null,
         array $headers = array()
     ) {
-        $this->checkConnection($method, $path, $data, $headers);
+        if ($this->options['path']) {
+            $full_path = '/' . $this->options['path'] . $path;
+        }
+
+        $this->checkConnection($method, $full_path, $data, $headers);
         return $this->httpFilePointer;
     }
 
@@ -170,10 +174,10 @@ class StreamClient extends AbstractHTTPClient
     public function request($method, $path, $data = null, $raw = false, array $headers = array())
     {
         if ($this->options['path']) {
-            $path = '/' . $this->options['path'] . $path;
+            $full_path = '/' . $this->options['path'] . $path;
         }
 
-        $this->checkConnection($method, $path, $data, $headers);
+        $this->checkConnection($method, $full_path, $data, $headers);
 
         // Read request body.
         $body = '';


### PR DESCRIPTION
When a database is not at the URL root CouchDB Client cannot be used, this pull request solves that issue by adding a 'path' option.

For example a database called "bar" may be at the URL example.com:5984/foo/bar.
It could be accessed using the following.
```
CouchDBClient::create(['host' => 'example.com', 'path' => 'foo', 'dbname' => 'bar']);
```

Care has been taken not to break the API and for any existing functionality to work.