### PR TITLE
Add port to host header

### DIFF
--- a/lib/Doctrine/CouchDB/HTTP/SocketClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/SocketClient.php
@@ -141,7 +141,12 @@ class SocketClient extends AbstractHTTPClient
         array $headers = array()
     ) {
         // Create basic request headers
-        $request = "$method $path HTTP/1.1\r\nHost: {$this->options['host']}\r\n";
+        $host = "Host: {$this->options['host']}";
+        // Add the port to the Host header
+        if ($this->options['port']) {
+            $host = "$host:{$this->options['port']}";
+        }
+        $request = "$method $path HTTP/1.1\r\n$host\r\n";
 
         // Add basic auth if set
         if ($this->options['username']) {

--- a/lib/Doctrine/CouchDB/HTTP/SocketClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/SocketClient.php
@@ -141,11 +141,7 @@ class SocketClient extends AbstractHTTPClient
         array $headers = array()
     ) {
         // Create basic request headers
-        $host = "Host: {$this->options['host']}";
-        // Add the port to the Host header
-        if ($this->options['port']) {
-            $host = "$host:{$this->options['port']}";
-        }
+        $host = "Host: {$this->options['host']}:{$this->options['port']}";
         $request = "$method $path HTTP/1.1\r\n$host\r\n";
 
         // Add basic auth if set


### PR DESCRIPTION
This will add the port to the `Host` header, now it will look like this: `localhost:8080` (host:port). This is necessary for systems that detect the port using the `Host` header. I've faced a problem when doing the replication using as target a Drupal site. The port is wrong at target (Drupal) for `_changes` requests, e.g. `http://localhost:8080/relaxed/default/_changes`, because it's missing from `Host` header. This fixes the problem.