### PR TITLE
Multipart requests with content size

### DIFF
--- a/lib/Doctrine/CouchDB/HTTP/HTTPException.php
+++ b/lib/Doctrine/CouchDB/HTTP/HTTPException.php
@@ -66,7 +66,7 @@ class HTTPException extends \Doctrine\CouchDB\CouchDBException
         }
 
         return new self(
-            "HTTP Error with status " . $response->status . " occoured while "
+            "HTTP Error with status " . $response->status . " occurred while "
                 . "requesting " . $path . ". Error: " . $response->body['error']
                 . " " . $response->body['reason'],
             $response->status );

--- a/lib/Doctrine/CouchDB/HTTP/MultipartParserAndSender.php
+++ b/lib/Doctrine/CouchDB/HTTP/MultipartParserAndSender.php
@@ -178,6 +178,11 @@ class MultipartParserAndSender
     {
         // Main response boundary of the multipart stream.
         $mainBoundary = trim($this->getNextLineFromSourceConnection());
+        // If on the first line we have the size, then main boundary should be
+        // on the second line.
+        if (is_numeric($mainBoundary)) {
+            $mainBoundary = trim($this->getNextLineFromSourceConnection());
+        }
 
         // Docs that don't have attachment.
         // These should be posted using Bulk upload.
@@ -193,7 +198,6 @@ class MultipartParserAndSender
                 continue;
 
             } elseif (strpos($line, 'Content-Type') !== false) {
-
 
                 list($header, $value) = explode(':', $line);
                 $header = trim($header);

--- a/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
@@ -74,7 +74,7 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
     public function testCreateDuplicateDatabaseThrowsException()
     {
         $this->couchClient->createDatabase($this->getTestDatabase());
-        $this->setExpectedException('Doctrine\CouchDB\HTTP\HTTPException', 'HTTP Error with status 412 occoured while requesting /'.$this->getTestDatabase().'. Error: file_exists The database could not be created, the file already exists.');
+        $this->setExpectedException('Doctrine\CouchDB\HTTP\HTTPException', 'HTTP Error with status 412 occurred while requesting /'.$this->getTestDatabase().'. Error: file_exists The database could not be created, the file already exists.');
         $this->couchClient->createDatabase($this->getTestDatabase());
     }
 
@@ -87,7 +87,7 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
         $this->assertEquals($this->getTestDatabase(), $data['db_name']);
 
         $notExistedDb = 'not_existed_db';
-        $this->setExpectedException('Doctrine\CouchDB\HTTP\HTTPException','HTTP Error with status 404 occoured while requesting /'.$notExistedDb.'. Error: not_found no_db_file');
+        $this->setExpectedException('Doctrine\CouchDB\HTTP\HTTPException','HTTP Error with status 404 occurred while requesting /'.$notExistedDb.'. Error: not_found no_db_file');
         $this->couchClient->getDatabaseInfo($notExistedDb);
     }
 
@@ -670,7 +670,7 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
 
         $this->setExpectedException(
             'Doctrine\CouchDB\HTTP\HTTPException',
-            'HTTP Error with status 404 occoured while requesting /doctrine_test_database/_design/foo/_view/not-found?. Error: not_found missing'
+            'HTTP Error with status 404 occurred while requesting /doctrine_test_database/_design/foo/_view/not-found?. Error: not_found missing'
         );
 
         $query->execute();

--- a/tests/Doctrine/Tests/CouchDB/Functional/HTTP/MultipartParserAndSenderTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/HTTP/MultipartParserAndSenderTest.php
@@ -234,11 +234,6 @@ EOT;
         );
         // Recreate DB
         $client->deleteDatabase($this->getTestDatabase());
-        // This should fix random failing test with this error: "HTTP Error with
-        // status 412 occurred while requesting /doctrine_test_database. Error:
-        // file_exists The database could not be created, the file already
-        // exists."
-        sleep(3);
         $client->createDatabase($this->getTestDatabase());
 
         // Doc id.

--- a/tests/Doctrine/Tests/CouchDB/Functional/HTTP/MultipartParserAndSenderTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/HTTP/MultipartParserAndSenderTest.php
@@ -234,6 +234,11 @@ EOT;
         );
         // Recreate DB
         $client->deleteDatabase($this->getTestDatabase());
+        // This should fix random failing test with this error: "HTTP Error with
+        // status 412 occurred while requesting /doctrine_test_database. Error:
+        // file_exists The database could not be created, the file already
+        // exists."
+        sleep(3);
         $client->createDatabase($this->getTestDatabase());
 
         // Doc id.


### PR DESCRIPTION
This makes possible to process multipart streams with the content size before boundary. 
Eg.:

```
231
--7b1596fc4940bc1be725ad67f11ec1c4
Content-Type: application/json

'{"_id": "123456","_rev": "1-abcde","foo":"baz"}'
```

I've faced a problem when using `curl` in PHP - when running the replication (with https://github.com/relaxedws/drupal-replication), if the first line is the content size, not the boundary, the replication fails. That because the `couchdb-client` always takes the main boundary from the first line in `MultipartParserAndSender::parseAndSend()`.