### PR TITLE
Append port to Host header only if not port 80

### DIFF
--- a/lib/Doctrine/CouchDB/HTTP/SocketClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/SocketClient.php
@@ -141,7 +141,10 @@ class SocketClient extends AbstractHTTPClient
         array $headers = array()
     ) {
         // Create basic request headers
-        $host = "Host: {$this->options['host']}:{$this->options['port']}";
+        $host = "Host: {$this->options['host']}";
+        if ($this->options['port'] != 80) {
+            $host .= ":{$this->options['port']}";
+        }
         $request = "$method $path HTTP/1.1\r\n$host\r\n";
 
         // Add basic auth if set

--- a/lib/Doctrine/CouchDB/HTTP/StreamClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/StreamClient.php
@@ -92,8 +92,12 @@ class StreamClient extends AbstractHTTPClient
         }
         if ($this->httpFilePointer == null) {
             // TODO SSL support?
+            $host = $this->options['host'];
+            if ($this->options['port'] != 80) {
+                $host .= ":{$this->options['port']}";
+            }
             $this->httpFilePointer = @fopen(
-                'http://' . $basicAuth . $this->options['host'] . ':' . $this->options['port'] . $path,
+                'http://' . $basicAuth . $host . $path,
                 'r',
                 false,
                 stream_context_create(


### PR DESCRIPTION
I discovered while using this code in a current project that some hosts will respond with a 404 when the Host header contains the default port (80).
This change appends the port only if it is not port 80.