### PR TITLE
Set default port to 80

### DIFF
--- a/lib/Doctrine/CouchDB/CouchDBClient.php
+++ b/lib/Doctrine/CouchDB/CouchDBClient.php
@@ -114,7 +114,7 @@ class CouchDBClient
         $defaults = array(
             'type' => 'socket',
             'host' => 'localhost',
-            'port' => 5984,
+            'port' => 80,
             'user' => null,
             'password' => null,
             'ip' => null,

--- a/lib/Doctrine/CouchDB/HTTP/AbstractHTTPClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/AbstractHTTPClient.php
@@ -22,7 +22,7 @@ abstract class AbstractHTTPClient implements Client
      */
     protected $options = array(
         'host'       => 'localhost',
-        'port'       => 5984,
+        'port'       => 80,
         'ip'         => '127.0.0.1',
         'ssl'        => false,
         'timeout'    => 0.01,
@@ -47,7 +47,7 @@ abstract class AbstractHTTPClient implements Client
      * @param string $path
      * @return \Doctrine\CouchDB\HTTP\AbstractHTTPClient
      */
-    public function __construct($host = 'localhost', $port = 5984, $username = null, $password = null, $ip = null , $ssl = false, $path = null, $timeout = 0.01)
+    public function __construct($host = 'localhost', $port = 80, $username = null, $password = null, $ip = null , $ssl = false, $path = null, $timeout = 0.01)
     {
         $this->options['host']     = (string) $host;
         $this->options['port']     = (int) $port;


### PR DESCRIPTION
I understand the default port for CouchDB is 5984, but the default port to the whole rest of HTTP is 80. This makes integrating in with other things a little tricky.

For example if using `GuzzleHttp\Psr7\Uri` (https://github.com/guzzle/psr7/blob/master/src/Uri.php) to generate a uri to pass to `Doctrine\CouchDB\CouchDBClient` if the port is 80 then the `Uri` class will not add it to the uri string. `CouchDBClient` will then assume the port is 5984, when it's not, it's 80!

If this PR gets accepted I will go one step further and set defaults to assume http is 80, and https is 443, because this is how all the things work.