### PR TITLE
Allow default headers to be set for clients

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ php:
   - 7.0
 
 before_script:
-  - curl -X PUT localhost:5984/doctrine_test_database
   - composer install
 
 script:

--- a/lib/Doctrine/CouchDB/CouchDBClient.php
+++ b/lib/Doctrine/CouchDB/CouchDBClient.php
@@ -122,6 +122,7 @@ class CouchDBClient
             'path' => null,
             'logging' => false,
             'timeout' => 10,
+            'headers' => array(),
         );
         $options = array_merge($defaults, $options);
 
@@ -139,7 +140,8 @@ class CouchDBClient
             $options['ip'],
             $options['ssl'],
             $options['path'],
-            $options['timeout']
+            $options['timeout'],
+            $options['headers']
         );
         if ($options['logging'] === true) {
             $connection = new HTTP\LoggingClient($connection);

--- a/lib/Doctrine/CouchDB/HTTP/AbstractHTTPClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/AbstractHTTPClient.php
@@ -30,6 +30,7 @@ abstract class AbstractHTTPClient implements Client
         'username'   => null,
         'password'   => null,
         'path'       => null,
+        'headers'    => array(),
     );
 
     /**
@@ -45,9 +46,11 @@ abstract class AbstractHTTPClient implements Client
      * @param string $ip
      * @param bool $ssl
      * @param string $path
+     * @param int $timeout
+     * @param array $headers
      * @return \Doctrine\CouchDB\HTTP\AbstractHTTPClient
      */
-    public function __construct($host = 'localhost', $port = 5984, $username = null, $password = null, $ip = null , $ssl = false, $path = null, $timeout = 10)
+    public function __construct($host = 'localhost', $port = 5984, $username = null, $password = null, $ip = null , $ssl = false, $path = null, $timeout = 10, array $headers = array())
     {
         $this->options['host']     = (string) $host;
         $this->options['port']     = (int) $port;
@@ -56,6 +59,7 @@ abstract class AbstractHTTPClient implements Client
         $this->options['password'] = $password;
         $this->options['path']     = $path;
         $this->options['timeout']  = (float) $timeout;
+        $this->options['headers']  = $headers;
 
         if ($ip === null) {
             $this->options['ip'] = gethostbyname($this->options['host']);
@@ -86,6 +90,7 @@ abstract class AbstractHTTPClient implements Client
             break;
 
         case 'http-log':
+        case 'headers':
         case 'password':
         case 'username':
             $this->options[$option] = $value;

--- a/lib/Doctrine/CouchDB/HTTP/MultipartParserAndSender.php
+++ b/lib/Doctrine/CouchDB/HTTP/MultipartParserAndSender.php
@@ -50,7 +50,8 @@ class MultipartParserAndSender
             $sourceOptions['ip'],
             $sourceOptions['ssl'],
             $sourceOptions['path'],
-            $sourceOptions['timeout']
+            $sourceOptions['timeout'],
+            $sourceOptions['headers']
         );
 
         $targetOptions = $target->getOptions();
@@ -62,7 +63,8 @@ class MultipartParserAndSender
             $targetOptions['ip'],
             $targetOptions['ssl'],
             $targetOptions['path'],
-            $targetOptions['timeout']
+            $targetOptions['timeout'],
+            $sourceOptions['headers']
         );
     }
 

--- a/lib/Doctrine/CouchDB/HTTP/SocketClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/SocketClient.php
@@ -159,6 +159,9 @@ class SocketClient extends AbstractHTTPClient
         // available in the locale net.
         $request .= "Connection: " . ($this->options['keep-alive'] ? 'Keep-Alive' : 'Close') . "\r\n";
 
+        if ($this->options['headers']) {
+            $headers = array_merge($this->options['headers'], $headers);
+        }
         if (!isset($headers['Content-Type'])) {
             $headers['Content-Type'] = 'application/json';
         }

--- a/lib/Doctrine/CouchDB/HTTP/StreamClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/StreamClient.php
@@ -81,6 +81,9 @@ class StreamClient extends AbstractHTTPClient
         if ($this->options['username']) {
             $basicAuth .= "{$this->options['username']}:{$this->options['password']}@";
         }
+        if ($this->options['headers']) {
+            $headers = array_merge($this->options['headers'], $headers);
+        }
         if (!isset($headers['Content-Type'])) {
             $headers['Content-Type'] = 'application/json';
         }

--- a/tests/Doctrine/Tests/CouchDB/CouchDBClientTest.php
+++ b/tests/Doctrine/Tests/CouchDB/CouchDBClientTest.php
@@ -39,6 +39,7 @@ class CouchDBClientTest extends \PHPUnit_Framework_TestCase
                 'timeout' => 10,
                 'keep-alive' => true,
                 'path' => null,
+                'headers' => array(),
             ),
             $client->getHttpClient()->getOptions()
         );
@@ -60,9 +61,22 @@ class CouchDBClientTest extends \PHPUnit_Framework_TestCase
                 'timeout' => 10,
                 'keep-alive' => true,
                 'path' => 'baz/qux',
+                'headers' => array(),
             ),
             $client->getHttpClient()->getOptions()
         );
+    }
+
+    public function testCreateClientWithDefaultHeaders()
+    {
+        $client = CouchDBClient::create(array('dbname' => 'test', 'headers' => array('X-Test' => 'test')));
+        $http_client = $client->getHttpClient();
+        $connection_options = $http_client->getOptions();
+        $this->assertSame(array('X-Test' => 'test'), $connection_options['headers']);
+
+        $http_client->setOption('headers', array('X-Test-New' => 'new'));
+        $connection_options = $http_client->getOptions();
+        $this->assertSame(array('X-Test-New' => 'new'), $connection_options['headers']);
     }
 
     public function testCreateClientWithLogging()

--- a/tests/Doctrine/Tests/CouchDB/CouchDBFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/CouchDB/CouchDBFunctionalTestCase.php
@@ -9,7 +9,12 @@ abstract class CouchDBFunctionalTestCase extends \PHPUnit_Framework_TestCase
 {
     private $httpClient = null;
 
-    /**
+    protected function tearDown() {
+        parent::tearDown();
+        $this->createCouchDBClient()->deleteDatabase($this->getTestDatabase());
+    }
+
+  /**
      * @return \Doctrine\CouchDB\HTTP\Client
      */
     public function getHttpClient()

--- a/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
@@ -14,6 +14,7 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
     public function setUp()
     {
         $this->couchClient = $this->createCouchDBClient();
+        $this->couchClient->createDatabase($this->getTestDatabase());
     }
 
     public function testGetUuids()
@@ -73,7 +74,6 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
      */
     public function testCreateDuplicateDatabaseThrowsException()
     {
-        $this->couchClient->createDatabase($this->getTestDatabase());
         $this->setExpectedException('Doctrine\CouchDB\HTTP\HTTPException', 'HTTP Error with status 412 occurred while requesting /'.$this->getTestDatabase().'. Error: file_exists The database could not be created, the file already exists.');
         $this->couchClient->createDatabase($this->getTestDatabase());
     }

--- a/tests/Doctrine/Tests/CouchDB/Functional/HTTP/MultipartParserAndSenderTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/HTTP/MultipartParserAndSenderTest.php
@@ -52,6 +52,12 @@ class MultipartParserAndSenderTest extends \Doctrine\Tests\CouchDB\CouchDBFuncti
 
     }
 
+    public function tearDown()
+    {
+        parent::tearDown();
+        $this->createCouchDBClient()->deleteDatabase($this->getTestDatabase() . '_multipart_copy');
+    }
+
     public function testRequestThrowsHTTPExceptionOnEmptyStatus()
     {
         $this->setExpectedException(


### PR DESCRIPTION
We have a need to set arbitrary headers on requests using the couch client - for our purpose, it's for auth headers, using a Bearer token. This allows another auth server to act as a proxy for the couch database server.

This adds a 'headers' option to the `CouchDBClient` and the `AbstractHTTPClient` classes, and implements merging of default headers with passed in headers in the concrete `SocketClient` and `StreamClient` classes.

I added some option handling test coverage for this in `CouchDBClientTest`.