### PR TITLE
Add method to retrieve documents using Mango Query

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_script:
   - sudo sh install-couchdb-2.0.0-travis-ci.sh
   - sleep 10
   - curl -X PUT localhost:5984/doctrine_test_database
+  - cd ..
   - composer install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ before_script:
   - curl -X PUT localhost:5984/doctrine_test_database
   - composer install
 
-script
+script:
   - php vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ php:
 before_script:
   - mkdir temp
   - cd temp
+  - sudo apt-get update
+  - wget https://github.com/rebar/rebar/wiki/rebar
+  - sudo chmod +x rebar
+  - sudo cp ./rebar /usr/local/bin/
   - wget https://raw.githubusercontent.com/afiskon/install-couchdb/master/install-couchdb.sh
   - sudo sh install-couchdb.sh
   - sleep 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: php
 
-services:
-  - couchdb
-
 php:
   - 5.4
   - 5.5
@@ -11,6 +8,12 @@ php:
   - 7.1
 
 before_script:
+  - mkdir temp
+  - cd temp
+  - wget https://raw.githubusercontent.com/afiskon/install-couchdb/master/install-couchdb.sh
+  - sudo sh install-couchdb.sh
+  - sleep 10
+  - curl -X PUT localhost:5984/doctrine_test_database
   - composer install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ php:
   - 7.1
 
 before_script:
-  - curl -X PUT localhost:5984/doctrine_test_database
   - composer install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
-sudo: true
+dist: trusty
+sudo: required
 
 php:
   - 5.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
 
 before_script:
   - curl -X PUT localhost:5984/doctrine_test_database

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+sudo: true
 
 php:
   - 5.4
@@ -10,15 +11,11 @@ php:
 before_script:
   - mkdir temp
   - cd temp
-  - sudo apt-get update
-  - wget https://github.com/rebar/rebar/wiki/rebar
-  - sudo chmod +x rebar
-  - sudo cp ./rebar /usr/local/bin/
-  - wget https://raw.githubusercontent.com/afiskon/install-couchdb/master/install-couchdb.sh
-  - sudo sh install-couchdb.sh
+  - git clone https://gist.github.com/9a8e74487573f25bd83b59aac328bf6d.git .
+  - sudo sh install-couchdb-2.0.0-travis-ci.sh
   - sleep 10
   - curl -X PUT localhost:5984/doctrine_test_database
   - composer install
 
-script:
+script
   - php vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Simple API that wraps around CouchDBs HTTP API.
 * Compaction Info and Triggering APIs
 * Replication API
 * Symfony Console Commands
+* Find Documents using Mango Query [CouchDB v.2.0.0]
 
 ## Installation
 
@@ -62,6 +63,10 @@ $client->deleteDocument($id, $rev);
 
 // Delete a database.
 $client->deleteDatabase($client->getDatabase());
+
+//Search documents using Mango Query CouchDB v2.0.0
+$allDocs = $client->find(['_id'=>['$gt'=>null]]);
+
 ```
 
 ### Views

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Doctrine CouchDB Client
 
-[![Build Status](https://travis-ci.org/doctrine/couchdb-client.png?branch=master)](https://travis-ci.org/doctrine/couchdb-client)
+[![Build Status](https://travis-ci.org/robsonvn/couchdb-client.png?branch=master)](https://travis-ci.org/robsonvn/couchdb-client)
 
-Simple API that wraps around CouchDBs HTTP API.
+Simple API that wraps around CouchDBs v2.0.0 HTTP API.
 
 ## Features
 
@@ -18,7 +18,7 @@ Simple API that wraps around CouchDBs HTTP API.
 * Compaction Info and Triggering APIs
 * Replication API
 * Symfony Console Commands
-* Find Documents using Mango Query [CouchDB v.2.0.0]
+* Find Documents using Mango Query
 
 ## Installation
 

--- a/lib/Doctrine/CouchDB/CouchDBClient.php
+++ b/lib/Doctrine/CouchDB/CouchDBClient.php
@@ -198,7 +198,7 @@ class CouchDBClient
     * Find documents using Mango Query
     * @param array $selector
     * @return HTTP\Response
-    */    
+    */
     public function find(array $selector = [])
     {
       $documentPath = '/' . $this->databaseName."/_find";

--- a/lib/Doctrine/CouchDB/CouchDBClient.php
+++ b/lib/Doctrine/CouchDB/CouchDBClient.php
@@ -195,6 +195,22 @@ class CouchDBClient
     }
 
     /**
+    * Find documents using Mango Query
+    * @param array $selector
+    * @return HTTP\Response
+    */    
+    public function find(array $selector = [])
+    {
+      $documentPath = '/' . $this->databaseName."/_find";
+
+      if(key($selector)!=='selector'){
+        $selector = ['selector' => $selector];
+      }
+
+      return $this->httpClient->request('POST', $documentPath, json_encode($selector,JSON_FORCE_OBJECT));
+    }
+
+    /**
      * Find a document by ID and return the HTTP response.
      *
      * @param string $id

--- a/lib/Doctrine/CouchDB/CouchDBClient.php
+++ b/lib/Doctrine/CouchDB/CouchDBClient.php
@@ -122,6 +122,7 @@ class CouchDBClient
             'path' => null,
             'logging' => false,
             'timeout' => 10,
+            'headers' => array(),
         );
         $options = array_merge($defaults, $options);
 
@@ -139,7 +140,8 @@ class CouchDBClient
             $options['ip'],
             $options['ssl'],
             $options['path'],
-            $options['timeout']
+            $options['timeout'],
+            $options['headers']
         );
         if ($options['logging'] === true) {
             $connection = new HTTP\LoggingClient($connection);

--- a/lib/Doctrine/CouchDB/HTTP/AbstractHTTPClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/AbstractHTTPClient.php
@@ -30,6 +30,7 @@ abstract class AbstractHTTPClient implements Client
         'username'   => null,
         'password'   => null,
         'path'       => null,
+        'headers'    => array(),
     );
 
     /**
@@ -45,9 +46,11 @@ abstract class AbstractHTTPClient implements Client
      * @param string $ip
      * @param bool $ssl
      * @param string $path
+     * @param int $timeout
+     * @param array $headers
      * @return \Doctrine\CouchDB\HTTP\AbstractHTTPClient
      */
-    public function __construct($host = 'localhost', $port = 5984, $username = null, $password = null, $ip = null , $ssl = false, $path = null, $timeout = 10)
+    public function __construct($host = 'localhost', $port = 5984, $username = null, $password = null, $ip = null , $ssl = false, $path = null, $timeout = 10, array $headers = array())
     {
         $this->options['host']     = (string) $host;
         $this->options['port']     = (int) $port;
@@ -56,6 +59,7 @@ abstract class AbstractHTTPClient implements Client
         $this->options['password'] = $password;
         $this->options['path']     = $path;
         $this->options['timeout']  = (float) $timeout;
+        $this->options['headers']  = $headers;
 
         if ($ip === null) {
             $this->options['ip'] = gethostbyname($this->options['host']);
@@ -86,6 +90,7 @@ abstract class AbstractHTTPClient implements Client
             break;
 
         case 'http-log':
+        case 'headers':
         case 'password':
         case 'username':
             $this->options[$option] = $value;

--- a/lib/Doctrine/CouchDB/HTTP/MultipartParserAndSender.php
+++ b/lib/Doctrine/CouchDB/HTTP/MultipartParserAndSender.php
@@ -50,7 +50,8 @@ class MultipartParserAndSender
             $sourceOptions['ip'],
             $sourceOptions['ssl'],
             $sourceOptions['path'],
-            $sourceOptions['timeout']
+            $sourceOptions['timeout'],
+            $sourceOptions['headers']
         );
 
         $targetOptions = $target->getOptions();
@@ -62,7 +63,8 @@ class MultipartParserAndSender
             $targetOptions['ip'],
             $targetOptions['ssl'],
             $targetOptions['path'],
-            $targetOptions['timeout']
+            $targetOptions['timeout'],
+            $sourceOptions['headers']
         );
     }
 

--- a/lib/Doctrine/CouchDB/HTTP/SocketClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/SocketClient.php
@@ -159,6 +159,9 @@ class SocketClient extends AbstractHTTPClient
         // available in the locale net.
         $request .= "Connection: " . ($this->options['keep-alive'] ? 'Keep-Alive' : 'Close') . "\r\n";
 
+        if ($this->options['headers']) {
+            $headers = array_merge($this->options['headers'], $headers);
+        }
         if (!isset($headers['Content-Type'])) {
             $headers['Content-Type'] = 'application/json';
         }

--- a/lib/Doctrine/CouchDB/HTTP/StreamClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/StreamClient.php
@@ -81,6 +81,9 @@ class StreamClient extends AbstractHTTPClient
         if ($this->options['username']) {
             $basicAuth .= "{$this->options['username']}:{$this->options['password']}@";
         }
+        if ($this->options['headers']) {
+            $headers = array_merge($this->options['headers'], $headers);
+        }
         if (!isset($headers['Content-Type'])) {
             $headers['Content-Type'] = 'application/json';
         }

--- a/lib/Doctrine/CouchDB/Utils/BulkUpdater.php
+++ b/lib/Doctrine/CouchDB/Utils/BulkUpdater.php
@@ -46,11 +46,6 @@ class BulkUpdater
         $this->databaseName = $databaseName;
     }
 
-    public function setAllOrNothing($allOrNothing)
-    {
-        $this->data['all_or_nothing'] = (bool)$allOrNothing;
-    }
-
     public function updateDocument($data)
     {
         $this->data['docs'][] = $data;

--- a/tests/Doctrine/Tests/CouchDB/CouchDBClientTest.php
+++ b/tests/Doctrine/Tests/CouchDB/CouchDBClientTest.php
@@ -39,6 +39,7 @@ class CouchDBClientTest extends \PHPUnit_Framework_TestCase
                 'timeout' => 10,
                 'keep-alive' => true,
                 'path' => null,
+                'headers' => array(),
             ),
             $client->getHttpClient()->getOptions()
         );
@@ -60,9 +61,22 @@ class CouchDBClientTest extends \PHPUnit_Framework_TestCase
                 'timeout' => 10,
                 'keep-alive' => true,
                 'path' => 'baz/qux',
+                'headers' => array(),
             ),
             $client->getHttpClient()->getOptions()
         );
+    }
+
+    public function testCreateClientWithDefaultHeaders()
+    {
+        $client = CouchDBClient::create(array('dbname' => 'test', 'headers' => array('X-Test' => 'test')));
+        $http_client = $client->getHttpClient();
+        $connection_options = $http_client->getOptions();
+        $this->assertSame(array('X-Test' => 'test'), $connection_options['headers']);
+
+        $http_client->setOption('headers', array('X-Test-New' => 'new'));
+        $connection_options = $http_client->getOptions();
+        $this->assertSame(array('X-Test-New' => 'new'), $connection_options['headers']);
     }
 
     public function testCreateClientWithLogging()

--- a/tests/Doctrine/Tests/CouchDB/CouchDBFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/CouchDB/CouchDBFunctionalTestCase.php
@@ -9,7 +9,12 @@ abstract class CouchDBFunctionalTestCase extends \PHPUnit_Framework_TestCase
 {
     private $httpClient = null;
 
-    /**
+    protected function tearDown() {
+        parent::tearDown();
+        $this->createCouchDBClient()->deleteDatabase($this->getTestDatabase());
+    }
+
+  /**
      * @return \Doctrine\CouchDB\HTTP\Client
      */
     public function getHttpClient()

--- a/tests/Doctrine/Tests/CouchDB/Functional/BulkUpdaterTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/BulkUpdaterTest.php
@@ -42,47 +42,7 @@ class BulkUpdaterTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCase
         $this->assertEquals(201, $response->status);
         $this->assertEquals(array(), $response->body);
     }
-
-    /**
-     * @depends testExecute
-     */
-    public function testSetAllOrNothing()
-    {
-        $docs[] = array("_id" => "test1", "foo" => "bar");
-        $docs[] = array("_id" => "test2", "bar" => "baz");
-        $this->bulkUpdater->updateDocuments($docs);
-        $response = $this->bulkUpdater->execute();
-        $revTest1 = $response->body[0]["rev"];
-
-        // Test with all_or_nothing=false.
-        // Try to update one doc with wrong or no _rev say test2. Only test1 should be updated.
-        $bulkUpdater2 = $this->couchClient->createBulkUpdater();
-        $bulkUpdater2->setAllOrNothing(false);
-        $docs2 = $docs;
-        $docs2[0]["should_be_updated"] = "true";
-        $docs2[0]["_rev"] = $revTest1;
-        $docs2[1]["should_be_updated"] = "false";
-        $bulkUpdater2->updateDocuments($docs2);
-        $response = $bulkUpdater2->execute();
-        $this->assertEquals(2, count($response->body));
-        $this->assertEquals(true, isset($response->body[0]["ok"]));
-        $this->assertEquals(false, isset($response->body[1]["ok"]));
-
-        // Test with all_or_nothing=true.
-        // Try to update one doc with wrong or no _rev say test2. Still both doc should get updated in case if there is
-        // any update at all.
-        $bulkUpdater3 = $this->couchClient->createBulkUpdater();
-        $bulkUpdater3->setAllOrNothing(true);
-        $docs3 = $docs;
-        $docs3[0]["should_be_updated"] = "true";
-        $docs3[0]["_rev"] = $revTest1;
-        $docs3[1]["should_be_updated"] = "true";
-        $bulkUpdater3->updateDocuments($docs3);
-        $response = $bulkUpdater3->execute();
-        $this->assertEquals(2, count($response->body));
-        $this->assertEquals(true, isset($response->body[0]["ok"]));
-        $this->assertEquals(true, isset($response->body[1]["ok"]));
-    }
+  
 
     /**
      * @depends testExecute

--- a/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
@@ -14,12 +14,12 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
     public function setUp()
     {
         $this->couchClient = $this->createCouchDBClient();
-        $this->couchClient->createDatabase($this->getTestDatabase());
+        $this->deleteAndCreateDatabase($this->getTestDatabase());
     }
 
     public function deleteAndCreateDatabase($databaseName){
       $this->couchClient->deleteDatabase($databaseName);
-      sleep(1);
+      sleep(0.5);
       $this->couchClient->createDatabase($databaseName);
     }
 
@@ -111,6 +111,12 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
      */
     public function testGetChanges()
     {
+        if(version_compare($this->couchClient->getVersion(),'2.0.0')<1){
+          $this->markTestSkipped(
+              'This test will not pass on version 2.0.0 due a result order bug. https://github.com/apache/couchdb/issues/513'
+            );
+        }
+
         $updater = $this->couchClient->createBulkUpdater();
         $updater->updateDocument(array("_id" => "test1", "foo" => "bar"));
         $updater->updateDocument(array("_id" => "test2", "bar" => "baz"));

--- a/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
@@ -93,7 +93,7 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
         $this->assertEquals($this->getTestDatabase(), $data['db_name']);
 
         $notExistedDb = 'not_existed_db';
-        
+
         $this->setExpectedException('Doctrine\CouchDB\HTTP\HTTPException','HTTP Error with status 404 occurred while requesting /'.$notExistedDb.'. Error: not_found Database does not exist');
 
         $this->couchClient->getDatabaseInfo($notExistedDb);
@@ -118,6 +118,7 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
 
         $changes = $this->couchClient->getChanges();
         $this->assertArrayHasKey('results', $changes);
+        exit;
         $this->assertEquals(2, count($changes['results']));
         $this->assertEquals(2, $changes['last_seq']);
 

--- a/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
@@ -114,23 +114,26 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
         $updater = $this->couchClient->createBulkUpdater();
         $updater->updateDocument(array("_id" => "test1", "foo" => "bar"));
         $updater->updateDocument(array("_id" => "test2", "bar" => "baz"));
-        $updater->execute();
+        $result = $updater->execute();
 
         $changes = $this->couchClient->getChanges();
+
         $this->assertArrayHasKey('results', $changes);
+
         $this->assertEquals(2, count($changes['results']));
-        $this->assertEquals(2, $changes['last_seq']);
+        $this->assertStringStartsWith('2', $changes['last_seq']);
 
 
         // Check the doc_ids parameter.
         $changes = $this->couchClient->getChanges(array(
             'doc_ids' => array('test1')
         ));
+
         $this->assertArrayHasKey('results', $changes);
         $this->assertEquals(1, count($changes['results']));
         $this->assertArrayHasKey('id', $changes['results'][0]);
         $this->assertEquals('test1', $changes['results'][0]['id']);
-        $this->assertEquals(2, $changes['last_seq']);
+        $this->assertStringStartsWith('2', $changes['last_seq']);
 
 
         $changes = $this->couchClient->getChanges(array(
@@ -138,16 +141,16 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
         ));
         $this->assertArrayHasKey('results', $changes);
         $this->assertEquals(2, count($changes['results']));
-        $this->assertEquals(2, $changes['last_seq']);
-        exit;
+        $this->assertStringStartsWith('2', $changes['last_seq']);
 
         // Check the limit parameter.
         $changes = $this->couchClient->getChanges(array(
             'limit' => 1,
         ));
+
         $this->assertArrayHasKey('results', $changes);
         $this->assertEquals(1, count($changes['results']));
-        $this->assertEquals(1, $changes['last_seq']);
+        $this->assertStringStartsWith('1', $changes['last_seq']);
 
         // Checks the descending parameter.
         $changes = $this->couchClient->getChanges(array(
@@ -156,7 +159,7 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
 
         $this->assertArrayHasKey('results', $changes);
         $this->assertEquals(2, count($changes['results']));
-        $this->assertEquals(1, $changes['last_seq']);
+        $this->assertStringStartsWith('1', $changes['last_seq']);
 
         // Checks the since parameter.
         $changes = $this->couchClient->getChanges(array(
@@ -165,7 +168,7 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
 
         $this->assertArrayHasKey('results', $changes);
         $this->assertEquals(1, count($changes['results']));
-        $this->assertEquals(2, $changes['last_seq']);
+        $this->assertStringStartsWith('2', $changes['last_seq']);
 
         // Checks the filter parameter.
         $designDocPath = __DIR__ . "/../../Models/CMS/_files";
@@ -178,7 +181,7 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
             'filter' => 'test-filter/my_filter'
         ));
         $this->assertEquals(1, count($changes['results']));
-        $this->assertEquals(3, $changes['last_seq']);
+        $this->assertStringStartsWith('3', $changes['last_seq']);
     }
 
     public function testPostDocument()

--- a/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
@@ -118,8 +118,8 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
 
         $changes = $this->couchClient->getChanges();
         $this->assertArrayHasKey('results', $changes);
-        exit;
         $this->assertEquals(2, count($changes['results']));
+        exit;
         $this->assertEquals(2, $changes['last_seq']);
 
         // Check the doc_ids parameter.

--- a/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
@@ -14,6 +14,7 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
     public function setUp()
     {
         $this->couchClient = $this->createCouchDBClient();
+        $this->couchClient->createDatabase($this->getTestDatabase());
     }
 
     public function deleteAndCreateDatabase($databaseName){
@@ -79,7 +80,6 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
      */
     public function testCreateDuplicateDatabaseThrowsException()
     {
-        $this->couchClient->createDatabase($this->getTestDatabase());
         $this->setExpectedException('Doctrine\CouchDB\HTTP\HTTPException', 'HTTP Error with status 412 occurred while requesting /'.$this->getTestDatabase().'. Error: file_exists The database could not be created, the file already exists.');
         $this->couchClient->createDatabase($this->getTestDatabase());
     }

--- a/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
@@ -119,8 +119,8 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
         $changes = $this->couchClient->getChanges();
         $this->assertArrayHasKey('results', $changes);
         $this->assertEquals(2, count($changes['results']));
-        exit;
         $this->assertEquals(2, $changes['last_seq']);
+        exit;
 
         // Check the doc_ids parameter.
         $changes = $this->couchClient->getChanges(array(

--- a/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
@@ -120,7 +120,7 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
         $this->assertArrayHasKey('results', $changes);
         $this->assertEquals(2, count($changes['results']));
         $this->assertEquals(2, $changes['last_seq']);
-        exit;
+
 
         // Check the doc_ids parameter.
         $changes = $this->couchClient->getChanges(array(
@@ -131,6 +131,8 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
         $this->assertArrayHasKey('id', $changes['results'][0]);
         $this->assertEquals('test1', $changes['results'][0]['id']);
         $this->assertEquals(2, $changes['last_seq']);
+
+                exit;
 
         $changes = $this->couchClient->getChanges(array(
             'doc_ids' => null

--- a/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
@@ -93,8 +93,11 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
         $this->assertEquals($this->getTestDatabase(), $data['db_name']);
 
         $notExistedDb = 'not_existed_db';
-        $this->setExpectedException('Doctrine\CouchDB\HTTP\HTTPException','HTTP Error with status 404 occurred while requesting /'.$notExistedDb.'. Error: not_found no_db_file');
+        
+        $this->setExpectedException('Doctrine\CouchDB\HTTP\HTTPException','HTTP Error with status 404 occurred while requesting /'.$notExistedDb.'. Error: not_found Database does not exist');
+
         $this->couchClient->getDatabaseInfo($notExistedDb);
+
     }
 
     public function testCreateBulkUpdater()

--- a/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
@@ -132,7 +132,6 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
         $this->assertEquals('test1', $changes['results'][0]['id']);
         $this->assertEquals(2, $changes['last_seq']);
 
-                exit;
 
         $changes = $this->couchClient->getChanges(array(
             'doc_ids' => null
@@ -140,6 +139,7 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
         $this->assertArrayHasKey('results', $changes);
         $this->assertEquals(2, count($changes['results']));
         $this->assertEquals(2, $changes['last_seq']);
+        exit;
 
         // Check the limit parameter.
         $changes = $this->couchClient->getChanges(array(

--- a/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
@@ -394,7 +394,7 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
         foreach (range(1, 3) as $i) {
             list($id, $rev) = $client->postDocument(array('foo' => 'bar' . $i));
             $ids[] = $id;
-            // This structure might be dependent from couchdb version. Tested against v1.6.1
+            // This structure might be dependent from couchdb version. Tested against v2.0.0
             $expectedRows[] = array(
                 'id' => $id,
                 'key' => $id,
@@ -439,7 +439,7 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
         foreach (range(1, 3) as $i) {
             list($id, $rev) = $client->postDocument(array('foo' => 'bar' . $i));
             $ids[] = $id;
-            // This structure might be dependent from couchdb version. Tested against v1.6.1
+            // This structure might be dependent from couchdb version. Tested against v2.0.0
             $expectedRows[] = array(
                 'id' => $id,
                 'value' => array(
@@ -744,7 +744,7 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
           $document = array('foo' => 'bar' . $i);
           list($id, $rev) = $client->postDocument($document);
           $ids[] = $id;
-          // This structure might be dependent from couchdb version. Tested against v.2.0.0
+          // This structure might be dependent from couchdb version. Tested against v2.0.0
           $document['_id'] = $id;
           $document['_rev'] = $rev;
           $expectedRows[] = $document;

--- a/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/CouchDBClientTest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Doctrine\Tests\CouchDB\Functional;
+
 use Doctrine\CouchDB\CouchDBClient;
 use Doctrine\CouchDB\View\FolderDesignDocument;
 
@@ -17,10 +18,12 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
         $this->deleteAndCreateDatabase($this->getTestDatabase());
     }
 
-    public function deleteAndCreateDatabase($databaseName){
-      $this->couchClient->deleteDatabase($databaseName);
-      sleep(0.5);
-      $this->couchClient->createDatabase($databaseName);
+
+    public function deleteAndCreateDatabase($databaseName)
+    {
+        $this->couchClient->deleteDatabase($databaseName);
+        sleep(0.5);
+        $this->couchClient->createDatabase($databaseName);
     }
 
     public function testGetUuids()
@@ -94,10 +97,9 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
 
         $notExistedDb = 'not_existed_db';
 
-        $this->setExpectedException('Doctrine\CouchDB\HTTP\HTTPException','HTTP Error with status 404 occurred while requesting /'.$notExistedDb.'. Error: not_found Database does not exist');
+        $this->setExpectedException('Doctrine\CouchDB\HTTP\HTTPException', 'HTTP Error with status 404 occurred while requesting /'.$notExistedDb.'. Error: not_found Database does not exist');
 
         $this->couchClient->getDatabaseInfo($notExistedDb);
-
     }
 
     public function testCreateBulkUpdater()
@@ -111,8 +113,8 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
      */
     public function testGetChanges()
     {
-        if(version_compare($this->couchClient->getVersion(),'2.0.0')<1){
-          $this->markTestSkipped(
+        if (version_compare($this->couchClient->getVersion(), '2.0.0')<1) {
+            $this->markTestSkipped(
               'This test will not pass on version 2.0.0 due a result order bug. https://github.com/apache/couchdb/issues/513'
             );
         }
@@ -545,40 +547,40 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
     public function testGetRevisionDifference()
     {
         $client = $this->couchClient;
-        $mapping = array (
+        $mapping = array(
             'baz' =>
-                array (
+                array(
                     0 => '2-7051cbe5c8faecd085a3fa619e6e6337',
                 ),
             'foo' =>
-                array (
+                array(
                     0 => '3-6a540f3d701ac518d3b9733d673c5484',
                 ),
             'bar' =>
-                array (
+                array(
                     0 => '1-d4e501ab47de6b2000fc8a02f84a0c77',
                     1 => '1-967a00dff5e02add41819138abb3284d',
                 ),
         );
-        $revisionDifference = array (
+        $revisionDifference = array(
             'baz' =>
-                array (
+                array(
                     'missing' =>
-                        array (
+                        array(
                             0 => '2-7051cbe5c8faecd085a3fa619e6e6337',
                         ),
                 ),
             'foo' =>
-                array (
+                array(
                     'missing' =>
-                        array (
+                        array(
                             0 => '3-6a540f3d701ac518d3b9733d673c5484',
                         ),
                 ),
             'bar' =>
-                array (
+                array(
                     'missing' =>
-                        array (
+                        array(
                             0 => '1-d4e501ab47de6b2000fc8a02f84a0c77',
                             1 => '1-967a00dff5e02add41819138abb3284d',
                         ),
@@ -607,18 +609,18 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
         // Doc id.
         $id = 'multiple_attachments';
         // Document with attachments.
-        $docWithAttachment = array (
+        $docWithAttachment = array(
             '_id' => $id,
             '_rev' => '1-abc',
             '_attachments' =>
-                array (
+                array(
                     'foo.txt' =>
-                        array (
+                        array(
                             'content_type' => 'text/plain',
                             'data' => 'VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ=',
                         ),
                     'bar.txt' =>
-                        array (
+                        array(
                             'content_type' => 'text/plain',
                             'data' => 'VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ=',
                         ),
@@ -682,11 +684,11 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
         $stream = $client->getChangesAsStream();
         list($id, $rev) = $client->postDocument(array("_id" => "stream1", "foo" => "bar"));
         // Get the change feed data for stream1.
-        while(trim($line = fgets($stream)) == '');
+        while (trim($line = fgets($stream)) == '');
         $this->assertEquals("stream1", json_decode($line, true)["id"]);
         list($id, $rev) = $client->postDocument(array("_id" => "stream2", "foo" => "bar"));
         // Get the change feed data for stream2.
-        while(trim($line = fgets($stream)) == '');
+        while (trim($line = fgets($stream)) == '');
         $this->assertEquals("stream2", json_decode($line, true)["id"]);
         fclose($stream);
     }
@@ -731,66 +733,201 @@ class CouchDBClientTest extends \Doctrine\Tests\CouchDB\CouchDBFunctionalTestCas
         $this->assertEquals(0, $result->getTotalRows());
     }
 
-    public function testFind(){
-      $client = $this->couchClient;
+    public function testFind()
+    {
+        $client = $this->couchClient;
 
-      // Recreate DB
-      $client->deleteDatabase($this->getTestDatabase());
-      $client->createDatabase($this->getTestDatabase());
+      //Recreate DB
+      $this->deleteAndCreateDatabase($this->getTestDatabase());
 
-      $ids = array();
-      $expectedRows = array();
-      foreach (range(1, 3) as $i) {
-          $document = array('foo' => 'bar' . $i);
-          list($id, $rev) = $client->postDocument($document);
-          $ids[] = $id;
-          // This structure might be dependent from couchdb version. Tested against v2.0.0
-          $document['_id'] = $id;
-          $document['_rev'] = $rev;
-          $expectedRows[] = $document;
-      }
+      $string = file_get_contents(__DIR__."/../../datasets/shows.json");
+        $shows = json_decode($string, true);
+
+        $updater = $this->couchClient->createBulkUpdater();
+        $updater->updateDocuments($shows);
+        $response = $updater->execute();
+
+        foreach ($response->body as $key=>$row) {
+            $shows[$key] = ['_id'=>$row["id"],'_rev'=>$row["rev"]] + $shows[$key];
+        }
 
       // Everything
-      $response = $client->find();
+      $response = $client->find([], [], [], 999);
 
-      $this->assertInstanceOf('\Doctrine\CouchDB\HTTP\Response', $response);
-      $this->assertObjectHasAttribute('body', $response);
-      $this->assertArrayHasKey('docs', $response->body);
+        $this->assertInstanceOf('\Doctrine\CouchDB\HTTP\Response', $response);
+        $this->assertObjectHasAttribute('body', $response);
+        $this->assertArrayHasKey('docs', $response->body);
 
-      $this->assertEquals($expectedRows, $response->body['docs']);
+        $this->assertEquals($shows, $response->body['docs']);
+
 
       //Query by a field with no index
-      $response = $client->find(['foo'=>['$eq'=>'bar1']]);
+      $response = $client->find(['name'=>['$eq'=>'Under the Dome']]);
 
-      $this->assertInstanceOf('\Doctrine\CouchDB\HTTP\Response', $response);
-      $this->assertObjectHasAttribute('body', $response);
-      $this->assertArrayHasKey('docs', $response->body);
+        $this->assertInstanceOf('\Doctrine\CouchDB\HTTP\Response', $response);
+        $this->assertObjectHasAttribute('body', $response);
+        $this->assertArrayHasKey('docs', $response->body);
       //No index found warning
       $this->assertArrayHasKey('warning', $response->body);
 
-      $this->assertEquals(array($expectedRows[0]), $response->body['docs']);
+        $this->assertEquals(array($shows[0]), $response->body['docs']);
 
       //Query by an indexed field
-      $response = $client->find(['_id'=>['$eq'=>$ids[1]]]);
+      $response = $client->find(['_id'=>['$eq'=>$shows[0]['_id']]]);
 
-      $this->assertInstanceOf('\Doctrine\CouchDB\HTTP\Response', $response);
-      $this->assertObjectHasAttribute('body', $response);
-      $this->assertArrayHasKey('docs', $response->body);
-      $this->assertArrayNotHasKey('warning', $response->body);
+        $this->assertInstanceOf('\Doctrine\CouchDB\HTTP\Response', $response);
+        $this->assertObjectHasAttribute('body', $response);
+        $this->assertArrayHasKey('docs', $response->body);
+        $this->assertArrayNotHasKey('warning', $response->body);
 
-      $this->assertEquals(array($expectedRows[1]), $response->body['docs']);
-
+        $this->assertEquals(array($shows[0]), $response->body['docs']);
 
       //Nothing
       $response = $client->find(['_id'=>['$eq'=>null]]);
+        $this->assertInstanceOf('\Doctrine\CouchDB\HTTP\Response', $response);
+        $this->assertObjectHasAttribute('body', $response);
+        $this->assertArrayHasKey('docs', $response->body);
+
+        $this->assertEquals(array(), $response->body['docs']);
+
+      //Selector Basics
+      $response = $client->find(['name'=>"Person of Interest"]);
+        $this->assertInstanceOf('\Doctrine\CouchDB\HTTP\Response', $response);
+        $this->assertObjectHasAttribute('body', $response);
+        $this->assertArrayHasKey('docs', $response->body);
+        $this->assertEquals(array($shows[1]), $response->body['docs']);
+
+      //Selector with 2 fields
+      $response = $client->find(['name'=>"Person of Interest","language"=>"English"]);
+        $this->assertInstanceOf('\Doctrine\CouchDB\HTTP\Response', $response);
+        $this->assertObjectHasAttribute('body', $response);
+        $this->assertArrayHasKey('docs', $response->body);
+        $this->assertEquals(array($shows[1]), $response->body['docs']);
+
+      //Condition Operators
+      $response = $client->find(['runtime'=>['$gt'=>60]]);
+        $this->assertInstanceOf('\Doctrine\CouchDB\HTTP\Response', $response);
+        $this->assertObjectHasAttribute('body', $response);
+        $this->assertArrayHasKey('docs', $response->body);
+        $this->assertEquals(2, count($response->body['docs']));
+
+      //Subfields
+      $response = $client->find(['rating'=>["average"=>8]]);
+        $this->assertInstanceOf('\Doctrine\CouchDB\HTTP\Response', $response);
+        $this->assertObjectHasAttribute('body', $response);
+        $this->assertArrayHasKey('docs', $response->body);
+        $this->assertEquals(9, count($response->body['docs']));
+
+      //Subfield with dot notation
+      $response = $client->find(['rating.average'=>8]);
+        $this->assertInstanceOf('\Doctrine\CouchDB\HTTP\Response', $response);
+        $this->assertObjectHasAttribute('body', $response);
+        $this->assertArrayHasKey('docs', $response->body);
+        $this->assertEquals(9, count($response->body['docs']));
+
+      //Explicit $and
+      $response = $client->find(
+        ['$and'=>
+          [
+            [
+              'name'=>[
+                '$eq'=>"Under the Dome"
+              ],
+              'genres'=>[
+                '$in'=>["Drama"]
+              ]
+            ]
+          ]
+        ]);
       $this->assertInstanceOf('\Doctrine\CouchDB\HTTP\Response', $response);
       $this->assertObjectHasAttribute('body', $response);
       $this->assertArrayHasKey('docs', $response->body);
+      $this->assertEquals(1, count($response->body['docs']));
+      $this->assertEquals(array($shows[0]), $response->body['docs']);
 
-      $this->assertEquals(array(), $response->body['docs']);
+      //$or operator
+      $response = $client->find(
+        [
+          'runtime'=>60,
+          '$or'=>[
+            [
+              "name"=>"Under the Dome"
+            ],
+            [
+              "name"=>"Person of Interest"
+            ]
+          ]
+        ]);
 
-      //Clean up
+      $this->assertInstanceOf('\Doctrine\CouchDB\HTTP\Response', $response);
+      $this->assertObjectHasAttribute('body', $response);
+      $this->assertArrayHasKey('docs', $response->body);
+      $this->assertEquals(2, count($response->body['docs']));
+      $this->assertEquals(array($shows[0],$shows[1]), $response->body['docs']);
+
+      //repeated key
+      $response = $client->find(
+        ['$and'=>
+          [
+            ['rating.average'=>['$gte'=>9]],
+            ['rating.average'=>['$lte'=>10]]
+          ]
+        ]);
+
+      $this->assertInstanceOf('\Doctrine\CouchDB\HTTP\Response', $response);
+      $this->assertObjectHasAttribute('body', $response);
+      $this->assertArrayHasKey('docs', $response->body);
+      $this->assertEquals(17, count($response->body['docs']));
+
+
+      //Limits and skips
+
+      //Get first
+      $response = $client->find([], [], [], 1);
+      $this->assertInstanceOf('\Doctrine\CouchDB\HTTP\Response', $response);
+      $this->assertObjectHasAttribute('body', $response);
+      $this->assertArrayHasKey('docs', $response->body);
+      $this->assertEquals(1, count($response->body['docs']));
+      $this->assertEquals(array($shows[0]), $response->body['docs']);
+
+      //Get second
+      $response = $client->find([], [], [], 1,1);
+      $this->assertInstanceOf('\Doctrine\CouchDB\HTTP\Response', $response);
+      $this->assertObjectHasAttribute('body', $response);
+      $this->assertArrayHasKey('docs', $response->body);
+      $this->assertEquals(1, count($response->body['docs']));
+      $this->assertEquals(array($shows[1]), $response->body['docs']);
+
+      //Select fields
+      $expected = [
+        [
+          'id'=>$shows[1]['id'],
+          'name'=>$shows[1]['name']
+        ]
+      ];
+      $response = $client->find([], ['id','name'], [], 1,1);
+      $this->assertInstanceOf('\Doctrine\CouchDB\HTTP\Response', $response);
+      $this->assertObjectHasAttribute('body', $response);
+      $this->assertArrayHasKey('docs', $response->body);
+      $this->assertEquals(1, count($response->body['docs']));
+      $this->assertEquals($expected, $response->body['docs']);
+
+      $expected = array();
+      for($i=count($shows)-1; $i>=0; $i--){
+        $row = [
+            '_id'=>$shows[$i]['_id'],
+            'name'=>$shows[$i]['name']
+        ];
+        $expected[] = $row;
+      }
+
+      $response = $client->find([], ['_id','name'], [['_id'=>"desc"]],999);
+      $this->assertInstanceOf('\Doctrine\CouchDB\HTTP\Response', $response);
+      $this->assertObjectHasAttribute('body', $response);
+      $this->assertArrayHasKey('docs', $response->body);
+      $this->assertEquals($expected, $response->body['docs']);
+
+      //Clean up*/
       $client->deleteDatabase($this->getTestDatabase());
     }
-
 }

--- a/tests/Doctrine/Tests/CouchDB/Functional/HTTP/MultipartParserAndSenderTest.php
+++ b/tests/Doctrine/Tests/CouchDB/Functional/HTTP/MultipartParserAndSenderTest.php
@@ -52,6 +52,12 @@ class MultipartParserAndSenderTest extends \Doctrine\Tests\CouchDB\CouchDBFuncti
 
     }
 
+    public function tearDown()
+    {
+        parent::tearDown();
+        $this->createCouchDBClient()->deleteDatabase($this->getTestDatabase() . '_multipart_copy');
+    }
+
     public function testRequestThrowsHTTPExceptionOnEmptyStatus()
     {
         $this->setExpectedException(

--- a/tests/Doctrine/Tests/datasets/shows.json
+++ b/tests/Doctrine/Tests/datasets/shows.json
@@ -1,0 +1,11494 @@
+[{
+    "id": 1,
+    "url": "http://www.tvmaze.com/shows/1/under-the-dome",
+    "name": "Under the Dome",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Science-Fiction", "Thriller"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2013-06-24",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Thursday"]
+    },
+    "rating": {
+        "average": 6.6
+    },
+    "weight": 0,
+    "network": {
+        "id": 2,
+        "name": "CBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 25988,
+        "thetvdb": 264492,
+        "imdb": "tt1553656"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/1.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/1.jpg"
+    },
+    "summary": "<p><strong>Under the Dome</strong> is the story of a small town that is suddenly and inexplicably sealed off from the rest of the world by an enormous transparent dome. The town's inhabitants must deal with surviving the post-apocalyptic conditions while searching for answers about the dome, where it came from and if and when it will go away.</p>",
+    "updated": 1490211618,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/1"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/185054"
+        }
+    }
+}, {
+    "id": 2,
+    "url": "http://www.tvmaze.com/shows/2/person-of-interest",
+    "name": "Person of Interest",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Crime", "Science-Fiction", "Thriller", "Mystery"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2011-09-22",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 9
+    },
+    "weight": 95,
+    "network": {
+        "id": 2,
+        "name": "CBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 28376,
+        "thetvdb": 248742,
+        "imdb": "tt1839578"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/55/137682.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/55/137682.jpg"
+    },
+    "summary": "<p>You are being watched. The government has a secret system, a machine that spies on you every hour of every day. I know because I built it. I designed the Machine to detect acts of terror but it sees everything. Violent crimes involving ordinary people. People like you. Crimes the government considered \"irrelevant.\" They wouldn't act so I decided I would. But I needed a partner. Someone with the skills to intervene. Hunted by the authorities, we work in secret. You'll never find us. But victim or perpetrator, if your number is up, we'll find you.</p>",
+    "updated": 1492964836,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/2"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/659372"
+        }
+    }
+}, {
+    "id": 3,
+    "url": "http://www.tvmaze.com/shows/3/bitten",
+    "name": "Bitten",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Fantasy", "Horror", "Romance"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2014-01-11",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 7.6
+    },
+    "weight": 89,
+    "network": {
+        "id": 7,
+        "name": "space",
+        "country": {
+            "name": "Canada",
+            "code": "CA",
+            "timezone": "Canada/Atlantic"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 34965,
+        "thetvdb": 269550,
+        "imdb": "tt2365946"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/15.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/15.jpg"
+    },
+    "summary": "<p>Based on the critically acclaimed series of novels from Kelley Armstrong. Set in Toronto and upper New York State, <strong>Bitten</strong> follows the adventures of 28-year-old Elena Michaels, the world's only female werewolf. An orphan, Elena thought she finally found her \"happily ever after\" with her new love Clayton, until her life changed forever. With one small bite, the normal life she craved was taken away and she was left to survive life with the Pack.</p>",
+    "updated": 1494681448,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/3"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/631862"
+        }
+    }
+}, {
+    "id": 4,
+    "url": "http://www.tvmaze.com/shows/4/arrow",
+    "name": "Arrow",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Science-Fiction"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2012-10-10",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Wednesday"]
+    },
+    "rating": {
+        "average": 7.8
+    },
+    "weight": 100,
+    "network": {
+        "id": 5,
+        "name": "The CW",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 30715,
+        "thetvdb": 257655,
+        "imdb": "tt2193021"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/75/189983.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/75/189983.jpg"
+    },
+    "summary": "<p>After a violent shipwreck, billionaire playboy Oliver Queen was missing and presumed dead for five years before being discovered alive on a remote island in the Pacific. He returned home to Starling City, welcomed by his devoted mother Moira, beloved sister Thea and former flame Laurel Lance. With the aid of his trusted chauffeur/bodyguard John Diggle, the computer-hacking skills of Felicity Smoak and the occasional, reluctant assistance of former police detective, now beat cop, Quentin Lance, Oliver has been waging a one-man war on crime.</p>",
+    "updated": 1494480937,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/4"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1099860"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1106521"
+        }
+    }
+}, {
+    "id": 5,
+    "url": "http://www.tvmaze.com/shows/5/true-detective",
+    "name": "True Detective",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Crime", "Thriller", "Mystery"],
+    "status": "To Be Determined",
+    "runtime": 60,
+    "premiered": "2014-01-12",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 8.5
+    },
+    "weight": 2,
+    "network": {
+        "id": 8,
+        "name": "HBO",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 31369,
+        "thetvdb": 270633,
+        "imdb": "tt2356777"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/61.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/61.jpg"
+    },
+    "summary": "<p>The series stars Matthew McConaughey and Woody Harrelson as Louisiana detectives Rust Cohle and Martin Hart, whose lives collide and entwine during a 17-year hunt for a killer, ranging from the original investigation of a bizarre murder in 1995 to the reopening of the case in 2012. Michelle Monaghan also stars as Hart's wife, Maggie, who struggles to keep her family together as the men in her life become locked in a cycle of violence and obsession.</p>",
+    "updated": 1478100215,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/5"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/182325"
+        }
+    }
+}, {
+    "id": 6,
+    "url": "http://www.tvmaze.com/shows/6/the-100",
+    "name": "The 100",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Action", "Adventure", "Science-Fiction"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2014-03-19",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Wednesday"]
+    },
+    "rating": {
+        "average": 7.9
+    },
+    "weight": 100,
+    "network": {
+        "id": 5,
+        "name": "The CW",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 34770,
+        "thetvdb": 268592,
+        "imdb": "tt2661044"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/94/236401.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/94/236401.jpg"
+    },
+    "summary": "<p>Ninety-seven years ago, nuclear Armageddon decimated planet Earth, destroying civilization. The only survivors were the 400 inhabitants of 12 international space stations that were in orbit at the time. Three generations have been born in space, the survivors now number 4,000, and resources are running out on their dying \"Ark\" - the 12 stations now linked together and repurposed to keep the surviv<span>ors alive. Draconian measures including capital punishment and population control are the order of the day, as the leaders of the Ark take ruthless steps to ensure their future, including secretly exiling a group of 100 juvenile prisoners to the Earth's surface to test whether it's habitable.</span></p>",
+    "updated": 1494495612,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/6"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1106148"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1049248"
+        }
+    }
+}, {
+    "id": 7,
+    "url": "http://www.tvmaze.com/shows/7/homeland",
+    "name": "Homeland",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Thriller", "Espionage"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2011-10-02",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 8.4
+    },
+    "weight": 100,
+    "network": {
+        "id": 9,
+        "name": "Showtime",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 27811,
+        "thetvdb": 247897,
+        "imdb": "tt1796960"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/101/254425.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/101/254425.jpg"
+    },
+    "summary": "<p>The winner of 6 Emmy Awards including Outstanding Drama Series, <strong>Homeland</strong> is an edge-of-your-seat sensation. Marine Sergeant Nicholas Brody is both a decorated hero and a serious threat. CIA officer Carrie Mathison is tops in her field despite being bipolar. The delicate dance these two complex characters perform, built on lies, suspicion, and desire, is at the heart of this gripping, emotional thriller in which nothing short of the fate of our nation is at stake.</p>",
+    "updated": 1491850005,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/7"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1066379"
+        }
+    }
+}, {
+    "id": 8,
+    "url": "http://www.tvmaze.com/shows/8/glee",
+    "name": "Glee",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Comedy", "Family", "Music"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2009-05-19",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 6.4
+    },
+    "weight": 0,
+    "network": {
+        "id": 4,
+        "name": "FOX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 21704,
+        "thetvdb": 83610,
+        "imdb": "tt1327801"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/73.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/73.jpg"
+    },
+    "summary": "<p><strong>Glee </strong>is a musical comedy about a group of ambitious and talented young adults in search of strength, acceptance and, ultimately, their voice.</p>",
+    "updated": 1486520272,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/8"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/142185"
+        }
+    }
+}, {
+    "id": 9,
+    "url": "http://www.tvmaze.com/shows/9/revenge",
+    "name": "Revenge",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Romance", "Thriller", "Mystery"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2011-09-21",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 7.8
+    },
+    "weight": 0,
+    "network": {
+        "id": 3,
+        "name": "ABC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 28387,
+        "thetvdb": 248837,
+        "imdb": "tt1837642"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/82/206879.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/82/206879.jpg"
+    },
+    "summary": "<p>This is not a story about forgiveness; <strong>Revenge</strong> is a show about retribution. Meet Emily Thorne, the newest resident of The Hamptons. When she was a little girl (and known as Amanda Clarke) her father, David Clarke, was framed for a horrific crime and subsequently sent to prison. While serving his time, the conspirators plotted and murdered David in order to prevent the truth from coming out. Emily is now back with a new identity and ready to take vengeance on the people that murdered her father and stole her childhood. </p>",
+    "updated": 1490253605,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/9"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/154117"
+        }
+    }
+}, {
+    "id": 10,
+    "url": "http://www.tvmaze.com/shows/10/grimm",
+    "name": "Grimm",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Crime", "Supernatural"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2011-10-28",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 8.5
+    },
+    "weight": 98,
+    "network": {
+        "id": 1,
+        "name": "NBC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 28352,
+        "thetvdb": 248736,
+        "imdb": "tt1830617"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/69/174906.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/69/174906.jpg"
+    },
+    "summary": "<p><strong>Grimm </strong>is a drama series inspired by the classic Grimm Brothers' Fairy Tales. After Portland homicide detective Nick Burkhardt discovers he's descended from an elite line of criminal profilers known as \"Grimms\", he increasingly finds his responsibilities as a detective at odds with his new responsibilities as a Grimm.</p>",
+    "updated": 1493302994,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/10"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1009811"
+        }
+    }
+}, {
+    "id": 11,
+    "url": "http://www.tvmaze.com/shows/11/gotham",
+    "name": "Gotham",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Crime", "Science-Fiction"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2014-09-22",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 7.9
+    },
+    "weight": 100,
+    "network": {
+        "id": 4,
+        "name": "FOX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 38049,
+        "thetvdb": 274431,
+        "imdb": "tt3749900"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/73/182550.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/73/182550.jpg"
+    },
+    "summary": "<p>The good. The evil. The beginning.</p><p> Everyone knows the name Commissioner Gordon. He is one of the crime world's greatest foes, a man whose reputation is synonymous with law and order. But what is known of Gordon's story and his rise from rookie detective to Police Commissioner? What did it take to navigate the multiple layers of corruption that secretly ruled Gotham City, the spawning ground of the world's most iconic villains? And what circumstances created them – the larger-than-life personas who would become Catwoman, The Penguin, The Riddler, Two-Face and The Joker? </p><p><strong>Gotham </strong>is an origin story of the great DC Comics Super-Villains and vigilantes, revealing an entirely new chapter that has never been told. It follows one cop's rise through a dangerously corrupt city teetering between good and evil, and chronicles the birth of one of the most popular super heroes of our time.</p>",
+    "updated": 1494693329,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/11"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1046842"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1046843"
+        }
+    }
+}, {
+    "id": 12,
+    "url": "http://www.tvmaze.com/shows/12/lost-girl",
+    "name": "Lost Girl",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Fantasy", "Horror"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2010-09-12",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 7.9
+    },
+    "weight": 0,
+    "network": {
+        "id": 6,
+        "name": "Showcase",
+        "country": {
+            "name": "Canada",
+            "code": "CA",
+            "timezone": "Canada/Atlantic"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 26401,
+        "thetvdb": 182061,
+        "imdb": "tt1429449"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/137.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/137.jpg"
+    },
+    "summary": "<p><strong>Lost Girl</strong> follows supernatural seductress Bo, a Succubus who feeds on the sexual energy of humans. Growing up with human parents, Bo had no reason to believe she was anything other than the girl next door — until she drained her boyfriend to death in their first sexual encounter. Now she has hit the road alone and afraid. <br /> She discovers she is one of the Fae, creatures of legend and folklore, who pass as humans while feeding off them secretly and in different ways, as they have for millennia. Relieved yet horrified to find out that she is not alone, Bo decides to take the middle path between the humans and the Fae while embarking on a personal mission to unlock the secrets of her origin.</p><p> With the help of her human sidekick, Kenzi, and Dyson, a sexy police detective, Bo takes on a challenge every week helping a Fae or human client who comes to her to solve a mystery, or to right a wrong.</p>",
+    "updated": 1488446233,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/12"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/316120"
+        }
+    }
+}, {
+    "id": 13,
+    "url": "http://www.tvmaze.com/shows/13/the-flash",
+    "name": "The Flash",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Science-Fiction"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2014-10-07",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 8.3
+    },
+    "weight": 100,
+    "network": {
+        "id": 5,
+        "name": "The CW",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 36939,
+        "thetvdb": 279121,
+        "imdb": "tt3107288"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/78/195988.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/78/195988.jpg"
+    },
+    "summary": "<p>After a particle accelerator causes a freak storm, CSI Investigator Barry Allen is struck by lightning and falls into a coma. Months later he awakens with the power of super speed, granting him the ability to move through Central City like an unseen guardian angel. Though initially excited by his newfound powers, Barry is shocked to discover he is not the only \"meta-human\" who was created in the wake of the accelerator explosion -- and not everyone is using their new powers for good. Barry partners with S.T.A.R. Labs and dedicates his life to protect the innocent. For now, only a few close friends and associates know that Barry is literally the fastest man alive, but it won't be long before the world learns what Barry Allen has become...The Flash!</p>",
+    "updated": 1494631003,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/13"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1106151"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1106152"
+        }
+    }
+}, {
+    "id": 14,
+    "url": "http://www.tvmaze.com/shows/14/continuum",
+    "name": "Continuum",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Crime", "Science-Fiction"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2012-05-27",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 8.2
+    },
+    "weight": 86,
+    "network": {
+        "id": 6,
+        "name": "Showcase",
+        "country": {
+            "name": "Canada",
+            "code": "CA",
+            "timezone": "Canada/Atlantic"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 30789,
+        "thetvdb": 258171,
+        "imdb": "tt1954347"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/184.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/184.jpg"
+    },
+    "summary": "<p><strong>Continuum </strong>is a one-hour police drama centered on Kiera Cameron, a regular cop from 65 years in the future who finds herself trapped in present day Vancouver. She is alone, a stranger in a strange land, and has eight of the most ruthless criminals from the future, known as Liber8, loose in the city.</p><p> Lucky for Kiera, through the use of her CMR (cellular memory recall), a futuristic liquid chip technology implanted in her brain, she connects with Alec Sadler, a seventeen-year-old tech genius. When Kiera calls and Alec answers, a very unique partnership begins.</p><p> Kiera's first desire is to get \"home.\" But until she figures out a way to do that, she must survive in our time period and use all the resources available to her to track and capture the terrorists before they alter history enough to change the course of the future. After all, what's the point of going back if the future isn't the one you left?</p>",
+    "updated": 1492795179,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/14"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/228308"
+        }
+    }
+}, {
+    "id": 15,
+    "url": "http://www.tvmaze.com/shows/15/constantine",
+    "name": "Constantine",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Fantasy", "Horror"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2014-10-24",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 7.4
+    },
+    "weight": 1,
+    "network": {
+        "id": 1,
+        "name": "NBC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 38109,
+        "thetvdb": 273690,
+        "imdb": "tt3489184"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/154.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/154.jpg"
+    },
+    "summary": "<p>Based on the wildly popular comic book series \"Hellblazer\" from DC Comics, seasoned demon hunter and master of the occult John Constantine is armed with a ferocious knowledge of the dark arts and a wickedly naughty wit. He fights the good fight - or at least he did. With his soul already damned to hell, he's decided to abandon his campaign against evil until a series of events thrusts him back into the fray, and he'll do whatever it takes to protect the innocent. With the balance of good and evil on the line‎, Constantine will use his skills to travel the country, find the supernatural terrors that threaten our world and send them back where they belong. After that, who knows... maybe there's hope for him and his soul after all.</p>",
+    "updated": 1487320010,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/15"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/122719"
+        }
+    }
+}, {
+    "id": 16,
+    "url": "http://www.tvmaze.com/shows/16/penny-dreadful",
+    "name": "Penny Dreadful",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Horror", "Thriller"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2014-05-11",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 8.2
+    },
+    "weight": 85,
+    "network": {
+        "id": 9,
+        "name": "Showtime",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": {
+        "id": 1,
+        "name": "Netflix",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "externals": {
+        "tvrage": 34172,
+        "thetvdb": 265766,
+        "imdb": "tt2628232"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/48/122237.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/48/122237.jpg"
+    },
+    "summary": "<p>Some of literature's most terrifying characters, including Dr. Frankenstein and his monster, Dorian Gray, and iconic figures from the novel Dracula are lurking in the darkest corners of Victorian London. They are joined by a core of original characters in a complex, frightening new narrative. <strong>Penny Dreadful </strong>is a psychological thriller filled with dark mystery and suspense, where personal demons from the past can be stronger than vampires, evil spirits and immortal beasts.</p>",
+    "updated": 1492097589,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/16"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/766196"
+        }
+    }
+}, {
+    "id": 18,
+    "url": "http://www.tvmaze.com/shows/18/the-amazing-race",
+    "name": "The Amazing Race",
+    "type": "Reality",
+    "language": "English",
+    "genres": ["Action", "Adventure", "Family", "Travel"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2001-09-05",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Thursday"]
+    },
+    "rating": {
+        "average": 8.2
+    },
+    "weight": 97,
+    "network": {
+        "id": 2,
+        "name": "CBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 5566,
+        "thetvdb": 77666,
+        "imdb": "tt0285335"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/173.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/173.jpg"
+    },
+    "summary": "<p><strong>The Amazing Race </strong>is an adventure reality show in which 10-12 teams race around the world and compete vs each other in very difficult tasks. Each team consists of two racers. At the end the winning team is granted 1 Million Dollars. The show is hosted by Phil Keoghan.</p>",
+    "updated": 1494621907,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/18"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1097548"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1101278"
+        }
+    }
+}, {
+    "id": 19,
+    "url": "http://www.tvmaze.com/shows/19/supernatural",
+    "name": "Supernatural",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Supernatural"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2005-09-13",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Thursday"]
+    },
+    "rating": {
+        "average": 8.4
+    },
+    "weight": 99,
+    "network": {
+        "id": 5,
+        "name": "The CW",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 5410,
+        "thetvdb": 78901,
+        "imdb": "tt0460681"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/80/200182.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/80/200182.jpg"
+    },
+    "summary": "<p>The show follows brothers Sam and Dean Winchester, who travel across America in a black 1967 Chevy Impala investigating and combating paranormal events and other unexplained occurrences, many of them based on American urban legends and folklore as well as classic supernatural creatures such as vampires, werewolves, and ghosts.</p>",
+    "updated": 1494624281,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/19"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1118286"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1098641"
+        }
+    }
+}, {
+    "id": 20,
+    "url": "http://www.tvmaze.com/shows/20/the-strain",
+    "name": "The Strain",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Fantasy", "Horror", "Thriller"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2014-07-13",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 7.6
+    },
+    "weight": 98,
+    "network": {
+        "id": 13,
+        "name": "FX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 33229,
+        "thetvdb": 276564,
+        "imdb": "tt2654620"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/70/175363.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/70/175363.jpg"
+    },
+    "summary": "<p><strong>The Strain </strong>is a drama based on Guillermo del Toro and Chuck Hogan's horror trilogy, about a vampiric virus that has infected New York and the battle of mammoth proportions that follows.</p>",
+    "updated": 1494351225,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/20"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/854880"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1128357"
+        }
+    }
+}, {
+    "id": 21,
+    "url": "http://www.tvmaze.com/shows/21/the-last-ship",
+    "name": "The Last Ship",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Thriller"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2014-06-22",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 7.9
+    },
+    "weight": 99,
+    "network": {
+        "id": 14,
+        "name": "TNT",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 33158,
+        "thetvdb": 269533,
+        "imdb": "tt2402207"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/60/150621.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/60/150621.jpg"
+    },
+    "summary": "<p>Their mission is simple: Find a cure. Stop the virus. Save the world. When a global pandemic wipes out eighty percent of the planet's population, the crew of a lone naval destroyer must find a way to pull humanity from the brink of extinction.</p>",
+    "updated": 1492150975,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/21"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/855858"
+        }
+    }
+}, {
+    "id": 22,
+    "url": "http://www.tvmaze.com/shows/22/true-blood",
+    "name": "True Blood",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Fantasy", "Horror", "Romance"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2008-09-07",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 7.8
+    },
+    "weight": 0,
+    "network": {
+        "id": 8,
+        "name": "HBO",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 12662,
+        "thetvdb": 82283,
+        "imdb": "tt0844441"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/241.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/241.jpg"
+    },
+    "summary": "<p><strong>True Blood </strong>is a horror/drama based on a series of novels called <em>The Southern American Vampires Mysteries</em>. It focuses on Sookie Stackhouse and her various encounters with vampires and other supernatural beings. The show is centred in the small town of Bon Temps in Louisiana. The show focuses heavily on the co-existence of humans with vampires. The show also touches on several other controversial issues involving equal rights, violence, discrimination and religion.</p>",
+    "updated": 1477180590,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/22"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1292"
+        }
+    }
+}, {
+    "id": 23,
+    "url": "http://www.tvmaze.com/shows/23/once-upon-a-time-in-wonderland",
+    "name": "Once Upon a Time in Wonderland",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Adventure", "Fantasy"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2013-10-10",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Thursday"]
+    },
+    "rating": {
+        "average": 6.6
+    },
+    "weight": 22,
+    "network": {
+        "id": 3,
+        "name": "ABC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 35215,
+        "thetvdb": 269654,
+        "imdb": "tt2802008"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/73/183661.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/73/183661.jpg"
+    },
+    "summary": "<p>In Victorian England, the young and beautiful Alice tells a tale of a strange new land that exists on the other side of a rabbit hole. An invisible cat, a hookah smoking caterpillar and playing-cards that talk are just some of the fantastic things she's seen during this impossible adventure. Surely this troubled girl must be insane, and her doctors aim to cure her with a treatment that will make her forget everything. Alice seems ready to put it all behind her, especially the painful memory of the genie she fell in love with and lost forever -- the handsome and mysterious Cyrus . But deep down Alice knows this world is real, and just in the nick of time the sardonic Knave of Hearts and the irrepressible White Rabbit arrive to save her from a doomed fate. Together the trio will take a tumble down the rabbit hole to this Wonderland where nothing is impossible.</p>",
+    "updated": 1493603400,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/23"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1313"
+        }
+    }
+}, {
+    "id": 24,
+    "url": "http://www.tvmaze.com/shows/24/hawaii-five-0",
+    "name": "Hawaii Five-0",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Crime"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2010-09-20",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 7.9
+    },
+    "weight": 99,
+    "network": {
+        "id": 2,
+        "name": "CBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 24840,
+        "thetvdb": 164541,
+        "imdb": "tt1600194"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/25/64995.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/25/64995.jpg"
+    },
+    "summary": "<p><strong>Hawaii Five-0</strong> is a contemporary take on the classic series about a new elite federalized task force whose mission is to wipe out the crime that washes up on the Islands' sun-drenched beaches. Detective Steve McGarrett, a decorated Naval officer-turned-cop, returned to Oahu to investigate his father's murder and stayed after Hawaii's former governor persuaded him to head up the new team: his rules, no red tape and full blanket authority to hunt down the biggest \"game\" in town. Joining McGarrett is Detective Danny \"Danno\" Williams, a relocated ex-New Jersey cop - a working man in paradise who prefers skyscrapers to the coastline - but who's committed to keeping the Islands safe for his young daughter; Chin Ho Kelly, an ex-Honolulu police detective and former protégé of McGarrett's father who was wrongly accused of corruption; Dr. Max Bergman, the quirky coroner; Chin's cousin, Kono Kalakaua, a beautiful and fearless native; and Captain Lou Grover, who formerly headed Hawaii's SWAT unit. Joining them is Jerry Ortega, a former classmate of Chin's and the Island's local conspiracy theorist. The state's brash FIVE-0 unit, who may spar and jest among themselves, remain determined to eliminate the seedy elements from the 50th state.</p>",
+    "updated": 1494689570,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/24"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1113962"
+        }
+    }
+}, {
+    "id": 25,
+    "url": "http://www.tvmaze.com/shows/25/hellsing",
+    "name": "Hellsing",
+    "type": "Animation",
+    "language": "Japanese",
+    "genres": ["Anime", "Horror"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2001-10-10",
+    "schedule": {
+        "time": "",
+        "days": []
+    },
+    "rating": {
+        "average": 8.9
+    },
+    "weight": 0,
+    "network": {
+        "id": 131,
+        "name": "Fuji TV",
+        "country": {
+            "name": "Japan",
+            "code": "JP",
+            "timezone": "Asia/Tokyo"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 9139,
+        "thetvdb": 71278,
+        "imdb": "tt0325547"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/247.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/247.jpg"
+    },
+    "summary": "<p><strong>Hellsing </strong>is a 13 part anime based on the manga of the same name. The plot is significantly difficult to that of the the manga although the characters are the same. The show mainly focuses on the hellsing institute that houses the anti-hero named Alucard who swore loyalty to the Helsing family many years before. Alucard being the first ever vampire takes on a new apprentice named Sera's.</p>",
+    "updated": 1477180849,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/25"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/398491"
+        }
+    }
+}, {
+    "id": 26,
+    "url": "http://www.tvmaze.com/shows/26/hellsing-ultimate",
+    "name": "Hellsing Ultimate",
+    "type": "Animation",
+    "language": "Japanese",
+    "genres": ["Drama", "Action", "Anime", "Horror"],
+    "status": "Ended",
+    "runtime": 50,
+    "premiered": "2006-02-10",
+    "schedule": {
+        "time": "12:00",
+        "days": []
+    },
+    "rating": {
+        "average": 9
+    },
+    "weight": 0,
+    "network": {
+        "id": 159,
+        "name": "TBS",
+        "country": {
+            "name": "Japan",
+            "code": "JP",
+            "timezone": "Asia/Tokyo"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 29109,
+        "thetvdb": 263688,
+        "imdb": "tt0495212"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/22/55037.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/22/55037.jpg"
+    },
+    "summary": "<p><strong>Hellsing Ultimate</strong>, unlike the 13 part <em>Hellsing</em> series, follows the manga of the same name very closely. Alucard being the main protagonist and anti-hero/vampire. <em>Hellsing Ultimate</em> is a 10 part series of OVAs whereby Alucard turns Sera's into a vampire. The main focus of the plot being on an enemy neo-nazi group.</p>",
+    "updated": 1477180934,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/26"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1437"
+        }
+    }
+}, {
+    "id": 27,
+    "url": "http://www.tvmaze.com/shows/27/berserk",
+    "name": "Berserk",
+    "type": "Animation",
+    "language": "Japanese",
+    "genres": ["Anime", "Fantasy", "Horror"],
+    "status": "Ended",
+    "runtime": 25,
+    "premiered": "1997-10-07",
+    "schedule": {
+        "time": "",
+        "days": []
+    },
+    "rating": {
+        "average": 9.3
+    },
+    "weight": 0,
+    "network": {
+        "id": 137,
+        "name": "NTV",
+        "country": {
+            "name": "Japan",
+            "code": "JP",
+            "timezone": "Asia/Tokyo"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 2764,
+        "thetvdb": 73752,
+        "imdb": "tt0318871"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/249.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/249.jpg"
+    },
+    "summary": "<p><strong>Berserk </strong>is a 25-part anime set in a dark fantasy/horror environment whereby the series focuses on the main character guts; a lone swordman who later meets up with a group of mercenaries called the band of the hawk. The leader of this band holds a strange necklace called a behelit that will only lead to evil.</p>",
+    "updated": 1477309959,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/27"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1462"
+        }
+    }
+}, {
+    "id": 28,
+    "url": "http://www.tvmaze.com/shows/28/californication",
+    "name": "Californication",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Comedy"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2007-08-13",
+    "schedule": {
+        "time": "21:30",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 7.9
+    },
+    "weight": 0,
+    "network": {
+        "id": 9,
+        "name": "Showtime",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 15319,
+        "thetvdb": 80349,
+        "imdb": "tt0904208"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/250.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/250.jpg"
+    },
+    "summary": "<p><strong>Californication </strong>is a comedy/drama series based around the writer Hank Moody. He moves to California and suffers a writers block as well as many other family and personal issues. His drinking and generally unhealthy lifestyle interrupts his relationships with his long term lover Karen and his daughter Becca as he struggles with his manager Charlie Runkle.</p>",
+    "updated": 1488918332,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/28"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1546"
+        }
+    }
+}, {
+    "id": 29,
+    "url": "http://www.tvmaze.com/shows/29/vikings",
+    "name": "Vikings",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "History"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2013-03-03",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Wednesday"]
+    },
+    "rating": {
+        "average": 9
+    },
+    "weight": 99,
+    "network": {
+        "id": 118,
+        "name": "History",
+        "country": {
+            "name": "Canada",
+            "code": "CA",
+            "timezone": "Canada/Atlantic"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 31136,
+        "thetvdb": 260449,
+        "imdb": "tt2306299"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/28/70747.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/28/70747.jpg"
+    },
+    "summary": "<p><strong>Vikings</strong> transports us to the brutal and mysterious world of Ragnar Lothbrok, a Viking warrior and farmer who yearns to explore - and raid - the distant shores across the ocean.</p>",
+    "updated": 1494357780,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/29"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1006531"
+        }
+    }
+}, {
+    "id": 30,
+    "url": "http://www.tvmaze.com/shows/30/american-horror-story",
+    "name": "American Horror Story",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Horror", "Thriller"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2011-10-05",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Wednesday"]
+    },
+    "rating": {
+        "average": 7.8
+    },
+    "weight": 96,
+    "network": {
+        "id": 13,
+        "name": "FX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 28776,
+        "thetvdb": 250487,
+        "imdb": "tt1844624"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/74/186623.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/74/186623.jpg"
+    },
+    "summary": "<p><strong>American Horror Story </strong>is an horror television anthology series. Each season is conceived as a self-contained miniseries, following a disparate set of characters and settings, and a storyline with its own beginning, middle, and end. While some actors appear for more than one year, they play completely different roles in each season.</p><p><strong>Season 6: Roanoke</strong></p><p>The story takes place in 2016 in North Carolina. Shelby Miller (Lily Rabe), her husband Matt (André Holland) and Matt's sister Lee (Adina Porter) appear on a documentary named <i>My Roanoke Nightmare</i> in order to recount a series of supernatural events that happen to them after Shelby and Matt relocate from Los Angeles to North Carolina following a miscarriage. During their stay at the house, the family find videotapes made by the previous owner of the house that detail the terrifying events that happened there. (Sarah Paulson) portrays Shelby during the reenactment sections of <i>My Roanoke Nightmare</i>, while (Cuba Gooding Jr.) and (Angela Bassett) portray Matt and Lee respectively. </p><p>The previous owner of the house, Dr. Elias Cunningham, is portrayed through reenactments by (Denis O'Hare), the founder of the house, Edward Philippe Mott, by (Evan Peters), the woman who threatens the Millers Tomasyn White by (Kathy Bates) and her son, Ambrose, by (Wes Bentley). (Cheyenne Jackson) plays the interviewer of the documentary.</p><p>-<em>The fifth season</em>, subtitled Hotel, premiered on October 7, 2015, and it focused on the Hotel Cortez in Los Angeles, California.</p><p>-<em>The fourth season</em>, subtitled Freak Show, takes place in Jupiter, Florida during 1952 and centers around one of the few remaining American freak shows.</p><p>-<em>The third season</em>, subtitled Coven, takes place in New Orleans, Louisiana, during 2013 and follows a coven of witches who face off against those who wish to destroy them.</p><p>-<em>The second season</em> was subtitled \"Asylum,\" and takes place in Massachusetts in 1964, largely in an institution for the criminally insane.</p><p>-<em>The first season</em> was retroactively subtitled \"Murder House,\" and focuses on a haunted house in Los Angeles in 2011.</p>",
+    "updated": 1493484172,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/30"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/878029"
+        }
+    }
+}, {
+    "id": 31,
+    "url": "http://www.tvmaze.com/shows/31/marvels-agents-of-shield",
+    "name": "Marvel's Agents of S.H.I.E.L.D.",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Action", "Adventure", "Science-Fiction"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2013-09-24",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 8
+    },
+    "weight": 100,
+    "network": {
+        "id": 3,
+        "name": "ABC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 32656,
+        "thetvdb": 263365,
+        "imdb": "tt2364582"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/100/251696.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/100/251696.jpg"
+    },
+    "summary": "<p>Phil Coulson heads an elite team of fellow agents with the worldwide\n law-enforcement organization known as S.H.I.E.L.D. (Strategic Homeland \nIntervention Enforcement and Logistics Division), as they investigate \nstrange occurrences around the globe. Its members -- \neach of whom brings a specialty to the group -- work with Coulson to \nprotect those who cannot protect themselves from extraordinary and \ninconceivable threats.</p>",
+    "updated": 1494605206,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/31"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1117445"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1117446"
+        }
+    }
+}, {
+    "id": 32,
+    "url": "http://www.tvmaze.com/shows/32/fargo",
+    "name": "Fargo",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Crime"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2014-04-15",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Wednesday"]
+    },
+    "rating": {
+        "average": 9
+    },
+    "weight": 100,
+    "network": {
+        "id": 13,
+        "name": "FX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 35276,
+        "thetvdb": 269613,
+        "imdb": "tt2802850"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/107/269526.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/107/269526.jpg"
+    },
+    "summary": "<p><strong>Fargo </strong>is an american crime drama with some dark comical elements inspired by the film <em>Fargo</em> written by the Coen brothers. It was met with considerable acclaim as insurance salesman Lester Nygaard faces off against the psychopath Lorne Malvo. </p>",
+    "updated": 1494622492,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/32"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1104768"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1104769"
+        }
+    }
+}, {
+    "id": 33,
+    "url": "http://www.tvmaze.com/shows/33/hemlock-grove",
+    "name": "Hemlock Grove",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Horror", "Thriller"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2013-04-19",
+    "schedule": {
+        "time": "",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 7.1
+    },
+    "weight": 0,
+    "network": null,
+    "webChannel": {
+        "id": 1,
+        "name": "Netflix",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "externals": {
+        "tvrage": 33272,
+        "thetvdb": 259948,
+        "imdb": "tt2309295"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/305.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/305.jpg"
+    },
+    "summary": "<p>Secrets are just a part of daily life in the small Pennsylvania town of <strong>Hemlock Grove</strong>, where the darkest evils hide in plain sight.</p>",
+    "updated": 1477181392,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/33"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/393772"
+        }
+    }
+}, {
+    "id": 34,
+    "url": "http://www.tvmaze.com/shows/34/helix",
+    "name": "Helix",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Action", "Adventure", "Horror", "Science-Fiction", "Thriller"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2014-01-10",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 6.5
+    },
+    "weight": 0,
+    "network": {
+        "id": 16,
+        "name": "Syfy",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 34277,
+        "thetvdb": 265912,
+        "imdb": "tt2758950"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/322.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/322.jpg"
+    },
+    "summary": "<p><strong>Helix </strong>is a science fiction thriller that focuses on a CDC expedition into the arctic. They go there to investigate the potential outbreak of a disease with no idea what they are getting themselves into. They encounter an almost zombie-like threat that could threaten mankind itself whilst the operator of the facility seems to know more than what he is saying.</p>",
+    "updated": 1490457330,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/34"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/143215"
+        }
+    }
+}, {
+    "id": 35,
+    "url": "http://www.tvmaze.com/shows/35/the-killing",
+    "name": "The Killing",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Crime", "Thriller", "Mystery"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2011-04-03",
+    "schedule": {
+        "time": "00:00",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 8.4
+    },
+    "weight": 0,
+    "network": {
+        "id": 20,
+        "name": "AMC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 27387,
+        "thetvdb": 210171,
+        "imdb": "tt1637727"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/326.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/326.jpg"
+    },
+    "summary": "<p><strong>The Killing </strong>is a crime drama television series based on the Danish series Forbrydelsen. It follows detectives Stephen Holder and Sarah Linden and their work as detectives investigating murders. Sarah Linden takes cases very seriously and has issues keeping her work and family separate, as she pairs up with recovering addict Stephen Holder to solve dark murders.</p>",
+    "updated": 1480901262,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/35"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1726"
+        }
+    }
+}, {
+    "id": 37,
+    "url": "http://www.tvmaze.com/shows/37/intruders",
+    "name": "Intruders",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Fantasy", "Thriller"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2014-08-23",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Saturday"]
+    },
+    "rating": {
+        "average": 6.4
+    },
+    "weight": 0,
+    "network": {
+        "id": 15,
+        "name": "BBC America",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 38479,
+        "thetvdb": 277500,
+        "imdb": "tt3552166"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/340.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/340.jpg"
+    },
+    "summary": "<p>A contemporary, chilling, paranormal tale set in the moody Pacific Northwest, the series spins a fascinating and complex web of drama. As strange, apparently unrelated events start happening, multiple story-lines - a missing wife, an assassin covering his crimes, a child on the run - begin to intertwine to reveal a conspiracy that will forever change our understanding of human nature.</p>",
+    "updated": 1457144029,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/37"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1808"
+        }
+    }
+}, {
+    "id": 38,
+    "url": "http://www.tvmaze.com/shows/38/z-nation",
+    "name": "Z Nation",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Action", "Horror", "Science-Fiction"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2014-09-12",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 7.3
+    },
+    "weight": 3,
+    "network": {
+        "id": 16,
+        "name": "Syfy",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 41883,
+        "thetvdb": 280494,
+        "imdb": "tt3843168"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/28/70731.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/28/70731.jpg"
+    },
+    "summary": "<p><strong>Z Nation</strong> starts three years after the zombie virus has gutted the country, a team of everyday heroes must transport the only known survivor of the plague from New York to California, where the last functioning viral lab waits for his blood. Although the antibodies he carries are the world's last, best hope for a vaccine, he hides a dark secret that threatens them all. With humankind's survival at stake, the ragtag band embarks on a journey of survival across three thousand miles of rusted-out post-apocalyptic America.</p>",
+    "updated": 1483088150,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/38"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/989873"
+        }
+    }
+}, {
+    "id": 39,
+    "url": "http://www.tvmaze.com/shows/39/resurrection",
+    "name": "Resurrection",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Fantasy", "Science-Fiction", "Mystery"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2014-03-09",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 6.8
+    },
+    "weight": 0,
+    "network": {
+        "id": 3,
+        "name": "ABC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 34321,
+        "thetvdb": 269650,
+        "imdb": "tt2647586"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/350.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/350.jpg"
+    },
+    "summary": "<p>The people of Arcadia, Missouri are forever changed when their deceased loved ones suddenly start to reappear. An 8-year-old American boy wakes up alone in a rice paddy in a rural Chinese province with no idea how he got there. Details start to emerge when the boy, who calls himself Jacob, recalls that his hometown is Arcadia, and an Immigration agent, J. Martin Bellamy, takes him there. The home he claims as his own is occupied by a 60-year-old couple, Henry and Lucille Langston, who lost their son, Jacob, more than 30 years ago. While they look different, young Jacob recognizes them as his parents. Lucille is overjoyed at the seeming miracle of her son's reappearance. Henry is reluctant to accept that Jacob is back. Those closest to the family want answers, including Sheriff Fred Langston, whose wife Barbara drowned 30 years ago while trying to save Jacob, and Fred's daughter, Maggie, a local doctor. Pastor Tom Hale seeks a spiritual reason for what's happening in his community. When things take an even more shocking turn, Maggie's life-long friend, Elaine Richards, finds herself drawn into Arcadia's growing mystery. Bellamy, an outsider in the town, joins forces with Maggie to figure out why the unexplainable is happening in Arcadia. As their investigation plays out, Maggie learns some unsettling truths about her own past. Will they be able to solve the mystery of Arcadia before the rest of the world catches on to events there? And will they be able to protect Jacob from forces beyond their control?</p>",
+    "updated": 1471040639,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/39"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/96538"
+        }
+    }
+}, {
+    "id": 40,
+    "url": "http://www.tvmaze.com/shows/40/death-note",
+    "name": "Death Note",
+    "type": "Animation",
+    "language": "Japanese",
+    "genres": ["Drama", "Anime", "Thriller", "Mystery"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2006-10-03",
+    "schedule": {
+        "time": "13:00",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 8.8
+    },
+    "weight": 0,
+    "network": {
+        "id": 137,
+        "name": "NTV",
+        "country": {
+            "name": "Japan",
+            "code": "JP",
+            "timezone": "Asia/Tokyo"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 13555,
+        "thetvdb": 79481,
+        "imdb": "tt0877057"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/361.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/361.jpg"
+    },
+    "summary": "<p><strong>Death Note </strong>is an anime series based around a manga of the same name whereby a human finds a death god's notebook. Any person's name written in this notebook will die. The main character who finds this noteboook is Light Yagami who faces off against an unfaced character named L who tries to challenge him.</p>",
+    "updated": 1490172852,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/40"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1865"
+        }
+    }
+}, {
+    "id": 41,
+    "url": "http://www.tvmaze.com/shows/41/last-man-standing",
+    "name": "Last Man Standing",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy", "Family"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2011-10-11",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 8.4
+    },
+    "weight": 95,
+    "network": {
+        "id": 3,
+        "name": "ABC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 28386,
+        "thetvdb": 248834,
+        "imdb": "tt1828327"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/102/256598.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/102/256598.jpg"
+    },
+    "summary": "<p>TV titan Tim Allen returns to ABC as Mike Baxter, world voyager and one daredevil of a marketing director who is about to face his greatest challenge yet...his family but he is the <strong>Last Man Standing</strong>.</p><p>After Mike's wife, Vanessa, (Nancy Travis) receives a promotion at work, Mike must spend more time in his female-dominated household. With years of advice and guidance from their nurturing mother, Mike's three daughters are not prepared for their old-fashioned, hotheaded father to take over. Especially 20-year-old Kristin, who's trying to raise her own son, Boyd, with more of a liberal approach than Mike can stand. Celeb-obsessed Mandy has plenty of issues with Mike's style, and even though sporty Eve has a lot in common with her pop, there's still room for friction.</p><p>When he isn't reclaiming the masculinity in his home, Mike works at the sporting goods man-cave, Outdoor Man: A place where men can buy guns, jerky and a camouflage recliner in one testosterone-fueled location. Mike's boss, Ed Alzate, took Mike off of his thrilling magazine expositions and stuck him in front of the computer to supervise the company's website. With the help of his naïve subordinate,Kyle, Mike runs the Outdoor Man video log, which not only explores the store's stock of man-gear, but also helps Mike express his biggest concern with the 21st century: \"What happened to men?\"</p>",
+    "updated": 1494462552,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/41"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1066925"
+        }
+    }
+}, {
+    "id": 42,
+    "url": "http://www.tvmaze.com/shows/42/sleepy-hollow",
+    "name": "Sleepy Hollow",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Mystery", "Supernatural"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2013-09-16",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 7.6
+    },
+    "weight": 98,
+    "network": {
+        "id": 4,
+        "name": "FOX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 34726,
+        "thetvdb": 269578,
+        "imdb": "tt2647544"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/81/204166.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/81/204166.jpg"
+    },
+    "summary": "<p><strong>Sleepy Hollow</strong> is a thrilling mystery-adventure drama series spanning two and a half centuries, in which a resurrected Ichabod Crane pairs up with a present-day police lieutenant to save the enigmatic town of Sleepy Hollow--and the world--from unprecedented evil.</p>",
+    "updated": 1494393963,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/42"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1077792"
+        }
+    }
+}, {
+    "id": 43,
+    "url": "http://www.tvmaze.com/shows/43/outlander",
+    "name": "Outlander",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Action", "Adventure", "Fantasy", "Romance", "History"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2014-08-09",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Saturday"]
+    },
+    "rating": {
+        "average": 8.4
+    },
+    "weight": 98,
+    "network": {
+        "id": 17,
+        "name": "Starz",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 36202,
+        "thetvdb": 270408,
+        "imdb": "tt3006802"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/373.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/373.jpg"
+    },
+    "summary": "<p><strong>Outlander </strong>follows the story of Claire Randall, a married combat nurse from 1945 who is mysteriously swept back in time to 1743, where she is immediately thrown into an unknown world where her life is threatened. When she is forced to marry Jamie, a chivalrous and romantic young Scottish warrior, a passionate affair is ignited that tears Claire's heart between two vastly different men in two irreconcilable lives.</p><p>The <em>Outlander</em> series, adapted from Diana Gabaldon's international best-selling books, spans the genres of romance, science fiction, history and adventure into one epic tale.</p>",
+    "updated": 1493915974,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/43"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/694287"
+        }
+    }
+}, {
+    "id": 44,
+    "url": "http://www.tvmaze.com/shows/44/scorpion",
+    "name": "Scorpion",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Thriller"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2014-09-22",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 7.4
+    },
+    "weight": 100,
+    "network": {
+        "id": 2,
+        "name": "CBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 40717,
+        "thetvdb": 281630,
+        "imdb": "tt3514324"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/75/188174.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/75/188174.jpg"
+    },
+    "summary": "<p><strong>Scorpion</strong>, inspired by a true story, is a high-octane drama about eccentric genius Walter O'Brien and his team of brilliant misfits who comprise the last line of defense against complex, high-tech threats of the modern age. As Homeland Security's new think tank, O'Brien's \"Scorpion\" team includes Toby Curtis an expert behaviorist who can read anyone; Happy Quinn, a mechanical prodigy; and Sylvester Dodd, a statistics guru. Pooling their extensive technological knowledge to solve mind-boggling predicaments amazes federal agent Cabe Gallo, who shares a harrowing history with O'Brien. However, while this socially awkward group is comfortable with each other's humor and quirks, life outside their circle confounds them, so they rely on Paige Dineen, who has a young, gifted son, to translate the world for them. At last, these nerdy masterminds have found the perfect job: a place where they can apply their exceptional brainpower to solve the nation's crises, while also helping each other learn how to fit in.</p>",
+    "updated": 1494606307,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/44"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1117440"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1113959"
+        }
+    }
+}, {
+    "id": 45,
+    "url": "http://www.tvmaze.com/shows/45/ncis-new-orleans",
+    "name": "NCIS: New Orleans",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Crime"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2014-09-23",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 8.1
+    },
+    "weight": 99,
+    "network": {
+        "id": 2,
+        "name": "CBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 38017,
+        "thetvdb": 278125,
+        "imdb": "tt3560084"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/382.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/382.jpg"
+    },
+    "summary": "<p><strong>NCIS: New Orleans</strong>is a drama about the local field office that investigates criminal cases involving military personnel in The Big Easy, a city known for its music, entertainment and decadence. Leading the team is Special Agent Dwayne Pride, a.k.a. \"King,\" a native of New Orleans who is driven by his need to do what is right. Working with Pride is Special Agent Christopher LaSalle, who plays hard but works harder and former ATF agent Sonja Percy, who is still adjusting to the team after years of solo undercover assignments. Supporting them is coroner Dr. Loretta Wade, who is as eccentric as she is smart; her brilliant, quirky Forensic Scientist, Sebastian Lund; and Investigative Computer Specialist Patton Plame, an animated and talented hacker. New to the team is Special Agent Tammy Gregorio, a tough, acerbic FBI agent with a mysterious past in New Orleans, who is sent from D.C. to investigate the NCIS team, but also work with Pride when high-risk cases threaten the city. This colorful city that harbors a dark side is a magnet for service personnel on leave, and when overindulgence is followed by trouble, Pride's team is at its best</p>",
+    "updated": 1494433496,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/45"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1117448"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1113960"
+        }
+    }
+}, {
+    "id": 46,
+    "url": "http://www.tvmaze.com/shows/46/forever",
+    "name": "Forever",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Crime", "Supernatural"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2014-09-22",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 8.4
+    },
+    "weight": 0,
+    "network": {
+        "id": 3,
+        "name": "ABC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 41038,
+        "thetvdb": 281535,
+        "imdb": "tt3487382"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/383.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/383.jpg"
+    },
+    "summary": "<p>Doctor Henry Morgan, New York City's star medical examiner, has a secret. He doesn't just study the dead to solve criminal cases, he does it to solve the mystery that has eluded him for 200 years - the answer to his own inexplicable immortality. This long life has given Henry remarkable observation skills which impresses his new partner, Detective Jo Martinez. Each week, a new case and their budding friendship will reveal layers of Henry's long and colorful past. Only his best friend and confidant, Abe knows Henry's secret.</p>",
+    "updated": 1475187313,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/46"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/153966"
+        }
+    }
+}, {
+    "id": 47,
+    "url": "http://www.tvmaze.com/shows/47/witches-of-east-end",
+    "name": "Witches of East End",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Fantasy", "Romance"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2013-10-06",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 7.7
+    },
+    "weight": 39,
+    "network": {
+        "id": 18,
+        "name": "Lifetime",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 32887,
+        "thetvdb": 267259,
+        "imdb": "tt2288064"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/392.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/392.jpg"
+    },
+    "summary": "<p>Based on Melissa de la Cruz's best-selling novel, <strong>Witches of East End</strong> centers on the mysterious Beauchamp family who live in the secluded seaside town\n of East End. Free-spirited artist Joanna Beauchamp is the mother of \nwild-child bartender Freya and shy librarian Ingrid, who are both gifted\n -- and cursed -- with a magic birthright, of which they are unaware. \nFreya notices bizarre o<span>ccurrences in her life when \nshe inexplicably finds herself drawn to the troubled brother of her \nwealthy fiance. But it isn't until Joanna's estranged sister appears \nwith a warning that could change the family's fate that the matriarch \nmust reveal to her daughters that they are immortal witches with \nuntapped powers, a revelation that turns their small-town life upside \ndown.</span></p>",
+    "updated": 1494406621,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/47"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/2004"
+        }
+    }
+}, {
+    "id": 48,
+    "url": "http://www.tvmaze.com/shows/48/madam-secretary",
+    "name": "Madam Secretary",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2014-09-21",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 8
+    },
+    "weight": 99,
+    "network": {
+        "id": 2,
+        "name": "CBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 37247,
+        "thetvdb": 281623,
+        "imdb": "tt3501074"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/399.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/399.jpg"
+    },
+    "summary": "<p><strong>Madam Secretary</strong> follows Elizabeth McCord, the shrewd, determined, newly appointed Secretary of State who drives international diplomacy, battles office politics and circumvents protocol as she negotiates global and domestic issues, both at the White House and at home. A college professor and a brilliant former CIA analyst who left for ethical reasons, Elizabeth returns to public life at the request of the President following the suspicious death of her predecessor. The President values her apolitical leanings, her deep knowledge of the Middle East, her flair for languages and her ability to not just think outside the box, but to not even acknowledge there is a box.</p>",
+    "updated": 1494259889,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/48"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1107594"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1107595"
+        }
+    }
+}, {
+    "id": 49,
+    "url": "http://www.tvmaze.com/shows/49/brooklyn-nine-nine",
+    "name": "Brooklyn Nine-Nine",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy", "Action", "Crime"],
+    "status": "Running",
+    "runtime": 30,
+    "premiered": "2013-09-17",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 8.3
+    },
+    "weight": 100,
+    "network": {
+        "id": 4,
+        "name": "FOX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 35774,
+        "thetvdb": 269586,
+        "imdb": "tt2467372"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/89/224747.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/89/224747.jpg"
+    },
+    "summary": "<p><strong>Brooklyn Nine-Nine</strong> is an ensemble comedy about a talented-but-carefree detective, a by-the-book police captain and their precinct colleagues. While based in the workplace, Brooklyn Nine-Nine is not really about the job – it's about the men and women behind the badge.</p>",
+    "updated": 1494615270,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/49"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1096399"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1096400"
+        }
+    }
+}, {
+    "id": 50,
+    "url": "http://www.tvmaze.com/shows/50/the-lottery",
+    "name": "The Lottery",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Science-Fiction", "Thriller"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2014-07-20",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 5.8
+    },
+    "weight": 0,
+    "network": {
+        "id": 18,
+        "name": "Lifetime",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 37857,
+        "thetvdb": 278447,
+        "imdb": "tt3314228"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/409.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/409.jpg"
+    },
+    "summary": "<p>Set within a dystopian future driven by a global fertility crisis, <strong>The Lottery </strong>reveals a world staring down the barrel of impending extinction as women have mysteriously stopped bearing children. After years of research, Dr. Alison Lennon and her team remarkably fertilize 100 embryos. However, her victory is short-lived when the Director of the U.S. Fertility Commission, Darius Hayes, takes government control of the lab and informs the President of the monumental scientific breakthrough. To determine which women will carry the prized embryos to term, Chief of Staff Vanessa Keller convinces the President to hold a national lottery and a battle over the control of the 100 embryos begins.</p>",
+    "updated": 1477181972,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/50"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/2045"
+        }
+    }
+}, {
+    "id": 51,
+    "url": "http://www.tvmaze.com/shows/51/the-knick",
+    "name": "The Knick",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Medical"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2014-08-08",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 8.7
+    },
+    "weight": 93,
+    "network": {
+        "id": 19,
+        "name": "Cinemax",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 36033,
+        "thetvdb": 279977,
+        "imdb": "tt2937900"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/417.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/417.jpg"
+    },
+    "summary": "<p>New York City, 1900: The Knickerbocker Hospital is home to groundbreaking surgeons, nurses and staff who push the boundaries of medicine in a time of astonishingly high mortality rates and zero antibiotics. The newly appointed leader of the surgery staff is the brilliant, arrogant renegade Dr. John Thackery, whose addiction to cocaine and opium is trumped only by his ambition for medical discovery and renown among his peers. Into the all-white staff and patient hospital comes the equally gifted Harvard graduate Dr. Algernon Edwards, who must fight for respect while trying to navigate the racially charged city. Trying to maintain its reputation for quality care while realizing a profit, the Knickerbocker makes an effort to attract wealthy clientele, while literally struggling to keep the lights on.</p>",
+    "updated": 1493673419,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/51"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/213032"
+        }
+    }
+}, {
+    "id": 52,
+    "url": "http://www.tvmaze.com/shows/52/how-to-get-away-with-murder",
+    "name": "How to Get Away with Murder",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Thriller", "Legal"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2014-09-25",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Thursday"]
+    },
+    "rating": {
+        "average": 7.8
+    },
+    "weight": 5,
+    "network": {
+        "id": 3,
+        "name": "ABC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 37307,
+        "thetvdb": 281620,
+        "imdb": "tt3205802"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/70/176534.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/70/176534.jpg"
+    },
+    "summary": "<p>The brilliant, charismatic and seductive Professor Annalise Keating gets entangled with four law students from her class, <strong>How to Get Away with Murder</strong>. Little do they know that they will have to apply what they learned to real life, in this masterful, sexy, suspense-driven legal thriller.</p>",
+    "updated": 1489366049,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/52"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1048224"
+        }
+    }
+}, {
+    "id": 53,
+    "url": "http://www.tvmaze.com/shows/53/nashville",
+    "name": "Nashville",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Music", "Romance"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2012-10-10",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Thursday"]
+    },
+    "rating": {
+        "average": 8.1
+    },
+    "weight": 97,
+    "network": {
+        "id": 173,
+        "name": "CMT",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 30808,
+        "thetvdb": 259055,
+        "imdb": "tt2281375"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/89/224913.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/89/224913.jpg"
+    },
+    "summary": "<p><strong>Nashville</strong> is set against the backdrop of the city's music scene and follows Rayna Jaymes and Juliette Barnes. Both women face personal and professional challenges as they navigate their paths as artists and individuals. Surrounding them, and often complicating their lives, are their family, friends and, in some cases, lovers, as well as the up-and-coming performers and songwriters trying to get ahead in the business. Music City can mean so many things to different people. In Nashville, musicians and songwriters are at the heart of the storm driven by their own ambitions. Some are fueled by their creativity and passion for fame. Others struggle to cope with the pressures of success and are doing everything in their power to stay on top.</p>",
+    "updated": 1493998958,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/53"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1074915"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1130740"
+        }
+    }
+}, {
+    "id": 54,
+    "url": "http://www.tvmaze.com/shows/54/legends",
+    "name": "Legends",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Crime", "Thriller"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2014-08-13",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 7.5
+    },
+    "weight": 86,
+    "network": {
+        "id": 14,
+        "name": "TNT",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 33288,
+        "thetvdb": 265074,
+        "imdb": "tt2402137"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/36/92018.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/36/92018.jpg"
+    },
+    "summary": "<p>Sean Bean stars in <strong>Legends, </strong>a suspense-filled drama based on the award-winning book by master spy novelist Robert Littell. Bean plays Martin Odum, an undercover agent working for the FBI's Deep Cover Operations (DCO) division. Martin has the uncanny ability to transform himself into a completely different person for each job. But he begins to question his own identity when a mysterious stranger suggests that Martin isn't the man he believes himself to be.</p>",
+    "updated": 1493673497,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/54"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/500560"
+        }
+    }
+}, {
+    "id": 55,
+    "url": "http://www.tvmaze.com/shows/55/red-band-society",
+    "name": "Red Band Society",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Comedy"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2014-09-17",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Wednesday"]
+    },
+    "rating": {
+        "average": 7.6
+    },
+    "weight": 0,
+    "network": {
+        "id": 4,
+        "name": "FOX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 38923,
+        "thetvdb": 281532,
+        "imdb": "tt3576794"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/441.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/441.jpg"
+    },
+    "summary": "<p>What if a hospital was your high school, boarding school and summer camp rolled into one? What if it was the place where you fell in love for the first time and made friendships that lasted a lifetime? And what if it was all weirdly hilarious and the most fun you ever had in your entire life? This is the world of <strong>Red Band Society</strong>.</p>",
+    "updated": 1491976229,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/55"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/117709"
+        }
+    }
+}, {
+    "id": 56,
+    "url": "http://www.tvmaze.com/shows/56/chicago-pd",
+    "name": "Chicago P.D.",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Crime"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2014-01-08",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Wednesday"]
+    },
+    "rating": {
+        "average": 8.8
+    },
+    "weight": 99,
+    "network": {
+        "id": 1,
+        "name": "NBC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 35802,
+        "thetvdb": 269641,
+        "imdb": "tt2805096"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/72/181982.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/72/181982.jpg"
+    },
+    "summary": "<p>District 21 of the Chicago Police Department is made up of two distinctly different groups. There are the uniformed cops who patrol the beat and go head to head with the city's street crimes. And there's the Intelligence Unit, the team that combats the city's major offenses - organized crime, drug trafficking, high profile murders and beyond. These are their stories.</p>",
+    "updated": 1494609586,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/56"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1098594"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1098595"
+        }
+    }
+}, {
+    "id": 57,
+    "url": "http://www.tvmaze.com/shows/57/black-ish",
+    "name": "Black-ish",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy", "Family"],
+    "status": "Running",
+    "runtime": 30,
+    "premiered": "2014-09-24",
+    "schedule": {
+        "time": "21:30",
+        "days": ["Wednesday"]
+    },
+    "rating": {
+        "average": 7.6
+    },
+    "weight": 98,
+    "network": {
+        "id": 3,
+        "name": "ABC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 38317,
+        "thetvdb": 281511,
+        "imdb": "tt3487356"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/78/197282.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/78/197282.jpg"
+    },
+    "summary": "<p>Andre 'Dre' Johnson has a great job, a beautiful wife, Rainbow, four kids, and a colonial home in the 'burbs. But has success brought too much assimilation for this black family? With a little help from his dad, Dre sets out to establish a sense of cultural identity for his family that honors their past while embracing the future.</p>",
+    "updated": 1494531091,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/57"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1149940"
+        }
+    }
+}, {
+    "id": 58,
+    "url": "http://www.tvmaze.com/shows/58/new-girl",
+    "name": "New Girl",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy", "Romance"],
+    "status": "Running",
+    "runtime": 30,
+    "premiered": "2011-09-20",
+    "schedule": {
+        "time": "20:30",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 7.3
+    },
+    "weight": 98,
+    "network": {
+        "id": 4,
+        "name": "FOX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 28304,
+        "thetvdb": 248682,
+        "imdb": "tt1826940"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/71/179078.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/71/179078.jpg"
+    },
+    "summary": "<p><strong>New Girl</strong> is a single-camera ensemble comedy starring Zooey Deschanel as Jess, an offbeat girl who - after a bad breakup - moves in with three single guys and essentially sets a bomb off in their lives.</p>",
+    "updated": 1492956566,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/58"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1099767"
+        }
+    }
+}, {
+    "id": 59,
+    "url": "http://www.tvmaze.com/shows/59/chicago-fire",
+    "name": "Chicago Fire",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2012-10-10",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 8.8
+    },
+    "weight": 99,
+    "network": {
+        "id": 1,
+        "name": "NBC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 30748,
+        "thetvdb": 258541,
+        "imdb": "tt2261391"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/72/181984.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/72/181984.jpg"
+    },
+    "summary": "<p>No job is more stressful, dangerous or exhilarating than those of the Firefighters, Rescue Squad and Paramedics of Chicago Firehouse 51. These are the courageous men and women who forge headfirst into danger when everyone else is running the other way and whose actions make the difference between life and death. These are their stories.</p>",
+    "updated": 1494425391,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/59"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1071377"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1071378"
+        }
+    }
+}, {
+    "id": 60,
+    "url": "http://www.tvmaze.com/shows/60/ncis",
+    "name": "NCIS",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Crime"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2003-09-23",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 8.7
+    },
+    "weight": 99,
+    "network": {
+        "id": 2,
+        "name": "CBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 4628,
+        "thetvdb": 72108,
+        "imdb": "tt0364845"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/91/229369.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/91/229369.jpg"
+    },
+    "summary": "<p><strong>NCIS</strong> (Naval Criminal Investigative Service) is more than just an action drama. With liberal doses of humor, it's a show that focuses on the sometimes complex and always amusing dynamics of a team forced to work together in high-stress situations. Leroy Jethro Gibbs, a former Marine gunnery sergeant, whose skills as an investigator are unmatched, leads this troupe of colorful personalities. Rounding out the team are Anthony DiNozzo, an ex-homicide detective whose instincts in the field are unparalleled and whose quick wit and humorous take on life make him a team favorite; the youthful and energetic forensic specialist Abby Sciuto, a talented scientist whose sharp mind matches her Goth style and eclectic tastes; Caitlin Todd, an ex-Secret Service Agent; and Timothy McGee, an MIT graduate whose brilliance with computers far overshadows his insecurities in the field; Assisting the team is medical examiner Dr. Donald \"Ducky\" Mallard, who knows it all because he's seen it all, and he's not afraid to let you know. From murder and espionage to terrorism and stolen submarines, these special agents travel the globe to investigate all crimes with Navy or Marine Corps ties.</p>",
+    "updated": 1494430244,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/60"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1117432"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1113958"
+        }
+    }
+}, {
+    "id": 61,
+    "url": "http://www.tvmaze.com/shows/61/orphan-black",
+    "name": "Orphan Black",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Science-Fiction", "Thriller"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2013-03-30",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Saturday"]
+    },
+    "rating": {
+        "average": 8.7
+    },
+    "weight": 96,
+    "network": {
+        "id": 7,
+        "name": "space",
+        "country": {
+            "name": "Canada",
+            "code": "CA",
+            "timezone": "Canada/Atlantic"
+        }
+    },
+    "webChannel": {
+        "id": 3,
+        "name": "Amazon Prime",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "externals": {
+        "tvrage": 33293,
+        "thetvdb": 260315,
+        "imdb": "tt2234222"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/111/277730.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/111/277730.jpg"
+    },
+    "summary": "<p><strong>Orphan Black</strong> is about Sarah, an outsider and orphan whose life changes dramatically after witnessing the suicide of a woman, \"Beth\", who looks just like her. Sarah takes her identity, her boyfriend and her money. But instead of solving her problems, the street-smart chameleon is thrust headlong into a kaleidoscopic mystery. She makes the dizzying discovery that she and the dead woman are clones... but are they the only ones? Sarah quickly finds herself caught in the middle of a deadly conspiracy, racing to find answers.</p>",
+    "updated": 1494394947,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/61"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/670692"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1065446"
+        }
+    }
+}, {
+    "id": 62,
+    "url": "http://www.tvmaze.com/shows/62/the-originals",
+    "name": "The Originals",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Romance", "Supernatural"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2013-10-03",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 8.3
+    },
+    "weight": 99,
+    "network": {
+        "id": 5,
+        "name": "The CW",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 34166,
+        "thetvdb": 266883,
+        "imdb": "tt2632424"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/100/251361.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/100/251361.jpg"
+    },
+    "summary": "<p><strong>The Originals</strong> is a spin-off show from the supernatural drama <em>The Vampire Diaries</em>. It is based in the city of New Orleans where the originals represent the original vampires. The show is primarily based around conflict between vampires, werewolves and witches in the city.</p>",
+    "updated": 1494678125,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/62"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1105938"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1097766"
+        }
+    }
+}, {
+    "id": 63,
+    "url": "http://www.tvmaze.com/shows/63/the-vampire-diaries",
+    "name": "The Vampire Diaries",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Romance", "Supernatural"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2009-09-10",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 7.7
+    },
+    "weight": 96,
+    "network": {
+        "id": 5,
+        "name": "The CW",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 21766,
+        "thetvdb": 95491,
+        "imdb": "tt1405406"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/88/220908.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/88/220908.jpg"
+    },
+    "summary": "<p><strong>The Vampire Diaries</strong> is a supernatural drama/romance based around Elena Gilbert who falls in love with a 163 year old vampire.</p><p>Based on a novel series by L.J. Smith.</p>",
+    "updated": 1494108431,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/63"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1079174"
+        }
+    }
+}, {
+    "id": 64,
+    "url": "http://www.tvmaze.com/shows/64/utopia",
+    "name": "Utopia",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Science-Fiction", "Thriller"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2013-01-15",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 8.7
+    },
+    "weight": 0,
+    "network": {
+        "id": 45,
+        "name": "Channel 4",
+        "country": {
+            "name": "United Kingdom",
+            "code": "GB",
+            "timezone": "Europe/London"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 32276,
+        "thetvdb": 264991,
+        "imdb": "tt2384811"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/474.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/474.jpg"
+    },
+    "summary": "<p><strong>Utopia</strong> is a British crime/thriller/action show based initially around a small group of people who find a rare manuscript of the same name. This leads the group to be targeted by a large organisation with little knowledge of the manuscript's relevance or importance.</p>",
+    "updated": 1481008490,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/64"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/2718"
+        }
+    }
+}, {
+    "id": 65,
+    "url": "http://www.tvmaze.com/shows/65/bones",
+    "name": "Bones",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Crime", "Medical"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2005-09-13",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 8.1
+    },
+    "weight": 97,
+    "network": {
+        "id": 4,
+        "name": "FOX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 2870,
+        "thetvdb": 75682,
+        "imdb": "tt0460627"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/80/201202.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/80/201202.jpg"
+    },
+    "summary": "<p>F.B.I. Agent Seeley Booth is teamed up with forensic anthropologist Dr. \nTemperance \"Bones\" Brennan to solve some of the most baffling and \nbizarre crimes ever. Booth depends on clues from the living, witnesses \nand suspects, while Brennan gathers evidence from the dead, relying on \nher uncanny ability to read clues left behind in the bones of the \nvictims.</p>",
+    "updated": 1494017424,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/65"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1067425"
+        }
+    }
+}, {
+    "id": 66,
+    "url": "http://www.tvmaze.com/shows/66/the-big-bang-theory",
+    "name": "The Big Bang Theory",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy"],
+    "status": "Running",
+    "runtime": 30,
+    "premiered": "2007-09-24",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Thursday"]
+    },
+    "rating": {
+        "average": 8.3
+    },
+    "weight": 100,
+    "network": {
+        "id": 2,
+        "name": "CBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 8511,
+        "thetvdb": 80379,
+        "imdb": "tt0898266"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/58/145601.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/58/145601.jpg"
+    },
+    "summary": "<p><strong>The Big Bang Theory</strong> is a comedy about brilliant physicists, Leonard and Sheldon, who are the kind of \"beautiful minds\" that understand how the universe works. But none of that genius helps them interact with people, especially women. All this begins to change when a free-spirited beauty named Penny moves in next door. Sheldon, Leonard's roommate, is quite content spending his nights playing Klingon Boggle with their socially dysfunctional friends, fellow Cal Tech scientists Wolowitz and Koothrappali. However, Leonard sees in Penny a whole new universe of possibilities... including love.</p>",
+    "updated": 1494671152,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/66"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1107587"
+        }
+    }
+}, {
+    "id": 67,
+    "url": "http://www.tvmaze.com/shows/67/greys-anatomy",
+    "name": "Grey's Anatomy",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Romance", "Medical"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2005-03-27",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Thursday"]
+    },
+    "rating": {
+        "average": 8.2
+    },
+    "weight": 99,
+    "network": {
+        "id": 3,
+        "name": "ABC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 3741,
+        "thetvdb": 73762,
+        "imdb": "tt0413573"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/69/174007.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/69/174007.jpg"
+    },
+    "summary": "<p>The doctors of Grey Sloan Memorial Hospital deal with life-or-death consequences on a daily basis -- it's in one another that they find comfort, friendship and, at times, more than friendship. Together they're discovering that neither medicine nor relationships can be defined in black and white. Real life only comes in shades of grey.</p>",
+    "updated": 1494608183,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/67"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1127352"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1127353"
+        }
+    }
+}, {
+    "id": 68,
+    "url": "http://www.tvmaze.com/shows/68/castle",
+    "name": "Castle",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Crime"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2009-03-09",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 8.4
+    },
+    "weight": 93,
+    "network": {
+        "id": 3,
+        "name": "ABC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 19267,
+        "thetvdb": 83462,
+        "imdb": "tt1219024"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/490.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/490.jpg"
+    },
+    "summary": "<p><strong>Castle</strong> follows Rick Castle who is one of the world's most successful crime authors. But when his rock star lifestyle isn't enough, this bad boy goes looking for new trouble and finds it working with smart, beautiful Detective Kate Beckett. Inspired by her professional record and intrigued by her buttoned-up personality, Castle's found the model for his bold new character whether she likes it or not. Now with the mayor's permission, Castle is helping solve crime with his own twist.</p>",
+    "updated": 1494696021,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/68"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/677824"
+        }
+    }
+}, {
+    "id": 69,
+    "url": "http://www.tvmaze.com/shows/69/the-blacklist",
+    "name": "The Blacklist",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Crime", "Thriller"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2013-09-23",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Thursday"]
+    },
+    "rating": {
+        "average": 8.6
+    },
+    "weight": 100,
+    "network": {
+        "id": 1,
+        "name": "NBC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 35048,
+        "thetvdb": 266189,
+        "imdb": "tt2741602"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/70/176255.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/70/176255.jpg"
+    },
+    "summary": "<p><strong>The Blacklist</strong> is a crime drama involving a former government agent who turned into a high-profile criminal turning himself in to the FBI offering to help catch criminals.</p>",
+    "updated": 1494586024,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/69"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1009954"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1009955"
+        }
+    }
+}, {
+    "id": 70,
+    "url": "http://www.tvmaze.com/shows/70/the-voice",
+    "name": "The Voice",
+    "type": "Reality",
+    "language": "English",
+    "genres": ["Family", "Music"],
+    "status": "Running",
+    "runtime": 120,
+    "premiered": "2011-04-26",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Monday", "Tuesday"]
+    },
+    "rating": {
+        "average": 8
+    },
+    "weight": 97,
+    "network": {
+        "id": 1,
+        "name": "NBC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 27447,
+        "thetvdb": 247824,
+        "imdb": "tt1839337"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/96/242126.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/96/242126.jpg"
+    },
+    "summary": "<p><strong>The Voice</strong> is a reality singing competition show where the idea is to find new singing talent via a series of auditions.</p>",
+    "updated": 1494608577,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/70"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1117479"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1117480"
+        }
+    }
+}, {
+    "id": 71,
+    "url": "http://www.tvmaze.com/shows/71/dancing-with-the-stars",
+    "name": "Dancing with the Stars",
+    "type": "Reality",
+    "language": "English",
+    "genres": [],
+    "status": "Running",
+    "runtime": 120,
+    "premiered": "2005-06-01",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 6.3
+    },
+    "weight": 95,
+    "network": {
+        "id": 3,
+        "name": "ABC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 3220,
+        "thetvdb": 79590,
+        "imdb": "tt0463398"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/501.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/501.jpg"
+    },
+    "summary": "<p><strong>Dancing with the Stars</strong> is an american dance competition show and especially the american version of the british show <em>Strictly Come Dancing</em>.</p>",
+    "updated": 1494159869,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/71"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1116405"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1116406"
+        }
+    }
+}, {
+    "id": 72,
+    "url": "http://www.tvmaze.com/shows/72/ncis-los-angeles",
+    "name": "NCIS: Los Angeles",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Crime"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2009-09-22",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 8.1
+    },
+    "weight": 99,
+    "network": {
+        "id": 2,
+        "name": "CBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 21934,
+        "thetvdb": 95441,
+        "imdb": "tt1378167"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/74/186723.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/74/186723.jpg"
+    },
+    "summary": "<p><strong>NCIS: Los Angeles</strong> is a drama about the high-stakes world of a division of NCIS that is charged with apprehending dangerous and elusive criminals that pose a threat to the nation's security. By assuming false identities and utilizing the most advanced technology, this team of highly-trained agents goes deep undercover, putting their lives on the line in the field to bring down their targets.</p>",
+    "updated": 1494270419,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/72"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1113647"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1113648"
+        }
+    }
+}, {
+    "id": 73,
+    "url": "http://www.tvmaze.com/shows/73/the-walking-dead",
+    "name": "The Walking Dead",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Horror", "Science-Fiction"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2010-10-31",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 8.5
+    },
+    "weight": 99,
+    "network": {
+        "id": 20,
+        "name": "AMC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 25056,
+        "thetvdb": 153021,
+        "imdb": "tt1520211"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/104/261726.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/104/261726.jpg"
+    },
+    "summary": "<p><strong>The Walking Dead</strong> tells the story of the months and years that follow after a zombie apocalypse. It follows a group of survivors, led by former police officer Rick Grimes, who travel in search of a safe and secure home. As the world overrun by the dead takes its toll on the survivors, their interpersonal conflicts present a greater danger to their continuing survival than the walkers that roam the country. Over time, the characters are changed by the constant exposure to death and some grow willing to do anything to survive.</p><p>Based on the comic book series of the same name by Robert Kirkman, Tony Moore, and Charlie Adlard.</p>",
+    "updated": 1494630067,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/73"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1063332"
+        }
+    }
+}, {
+    "id": 74,
+    "url": "http://www.tvmaze.com/shows/74/hell-on-wheels",
+    "name": "Hell on Wheels",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Western"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2011-11-06",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Saturday"]
+    },
+    "rating": {
+        "average": 8.6
+    },
+    "weight": 72,
+    "network": {
+        "id": 20,
+        "name": "AMC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 27195,
+        "thetvdb": 212961,
+        "imdb": "tt1699748"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/526.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/526.jpg"
+    },
+    "summary": "<p><strong>Hell on Wheels</strong> is an American Western television series about the construction of the First Transcontinental Railroad across the United States. The series follows the Union Pacific Railroad and its surveyors, laborers, prostitutes, mercenaries, and others who lived, worked and died in the mobile encampment called \"Hell on Wheels\" that followed the railhead west across the Great Plains. In particular, the story focuses on Cullen Bohannon, a former Confederate soldier who, while working as foreman and chief engineer on the railroad, initially attempts to track down the Union soldiers who murdered his wife and young son during the American Civil War.</p>",
+    "updated": 1494499493,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/74"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/862325"
+        }
+    }
+}, {
+    "id": 75,
+    "url": "http://www.tvmaze.com/shows/75/the-mindy-project",
+    "name": "The Mindy Project",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy", "Romance", "Medical"],
+    "status": "Running",
+    "runtime": 30,
+    "premiered": "2012-09-25",
+    "schedule": {
+        "time": "",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 7.4
+    },
+    "weight": 93,
+    "network": null,
+    "webChannel": {
+        "id": 2,
+        "name": "Hulu",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "externals": {
+        "tvrage": 31682,
+        "thetvdb": 259007,
+        "imdb": "tt2211129"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/547.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/547.jpg"
+    },
+    "summary": "<p><strong>The Mindy Project</strong> is a single-camera comedy series which follows a skilled OB/GYN navigating the tricky waters of both her personal and professional life.</p>",
+    "updated": 1493572929,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/75"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1100987"
+        }
+    }
+}, {
+    "id": 76,
+    "url": "http://www.tvmaze.com/shows/76/sons-of-anarchy",
+    "name": "Sons of Anarchy",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Crime", "Thriller"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2008-09-03",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 8.8
+    },
+    "weight": 89,
+    "network": {
+        "id": 13,
+        "name": "FX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 18174,
+        "thetvdb": 82696,
+        "imdb": "tt1124373"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/537.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/537.jpg"
+    },
+    "summary": "<p><strong>Sons of Anarchy</strong> is an American television drama series created by Kurt Sutter, about the lives of a close-knit outlaw motorcycle club operating in Charming, a fictional town in California's Central Valley. The show centers on protagonist Jackson \"Jax\" Teller (Charlie Hunnam), initially the vice president of the club, who begins questioning the club and himself.</p>",
+    "updated": 1493113580,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/76"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/15832"
+        }
+    }
+}, {
+    "id": 77,
+    "url": "http://www.tvmaze.com/shows/77/the-middle",
+    "name": "The Middle",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy", "Family"],
+    "status": "Running",
+    "runtime": 30,
+    "premiered": "2009-09-30",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 8.1
+    },
+    "weight": 98,
+    "network": {
+        "id": 3,
+        "name": "ABC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 20678,
+        "thetvdb": 95021,
+        "imdb": "tt1442464"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/562.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/562.jpg"
+    },
+    "summary": "<p>Forget about athletes, movie stars and politicians. Parents are the real heroes - but we think Frankie Heck, must be some kind of superhero. A loving wife and mother of three, she's middle class in the middle of the country and is rapidly approaching middle age.</p><p>Frankie and her husband, Mike, have lived in Orson, Indiana, their whole lives. A man of few words (every one a zinger), Mike is a manager at the town quarry and Frankie is the third-best used car salesman (out of the three) at the local dealership. She may not be a high-powered career woman, but when it comes to her family, she'll go to just about any length. And with kids like these, she had better. There's Axl, her semi-nudist teenage son conceived while under the influence of Guns N' Roses; Sue, the awkward teenage daughter who fails at everything... but with the utmost of gusto; and their seven-year-old son Brick, whose best friend is his backpack.</p><p>Sometimes it seems like everyone is trying to get to the top, or struggling not to hit bottom, but we think Frankie and her family will find a lot of love, and a lot of laughs, somewhere in <strong>The Middle</strong>.</p>",
+    "updated": 1494546428,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/77"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1127333"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1127334"
+        }
+    }
+}, {
+    "id": 78,
+    "url": "http://www.tvmaze.com/shows/78/the-mysteries-of-laura",
+    "name": "The Mysteries of Laura",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy", "Crime"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2014-09-17",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Wednesday"]
+    },
+    "rating": {
+        "average": 7.6
+    },
+    "weight": 0,
+    "network": {
+        "id": 1,
+        "name": "NBC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 37263,
+        "thetvdb": 278462,
+        "imdb": "tt3187578"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/568.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/568.jpg"
+    },
+    "summary": "<p>Laura Diamond is a brilliant NYPD homicide detective who balances her \"Columbo\" day job with a crazy family life that includes two unruly twin boys and a soon-to-be ex-husband - also a cop - who just can't seem to sign the divorce papers. Between cleaning up after her boys and cleaning up the streets, she'd be the first to admit she has her \"hot mess\" moments in this hilariously authentic look at what it really means to be a working mom today. Somehow, she makes it all work with the help of her sexy and understanding partner, and things becomes even more complicated when her husband becomes her boss at the precinct. For Laura, every day is a high-wire balancing act.</p>",
+    "updated": 1490419691,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/78"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/609073"
+        }
+    }
+}, {
+    "id": 79,
+    "url": "http://www.tvmaze.com/shows/79/the-goldbergs",
+    "name": "The Goldbergs",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy", "Family"],
+    "status": "Running",
+    "runtime": 30,
+    "premiered": "2013-09-24",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Wednesday"]
+    },
+    "rating": {
+        "average": 8.2
+    },
+    "weight": 98,
+    "network": {
+        "id": 3,
+        "name": "ABC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 35814,
+        "thetvdb": 269653,
+        "imdb": "tt2712740"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/570.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/570.jpg"
+    },
+    "summary": "<p>Before there were parenting blogs, trophies for showing up and peanut allergies, there was a simpler time called the '80s. For geeky and movie obsessed youngest child Adam, these were his wonder years, and he faced them armed with a video camera to capture all the crazy. <strong>The Goldbergs</strong> are a loving family like any other -- just with a lot more yelling. Mom Beverly is a classic \"smother,\" an overbearing, overprotective matriarch who loves her delicious kids, but still rules this brood with 100% authority and zero sense of boundaries. Dad Murray is gruff and sometimes oblivious, parenting with half his attention span but all his heart. Sister Erica is popular and terrifying, doing her best to cover up that she's the smartest of the clan. Barry is a passionate dreamer, who maybe dreams a little too big and who always gets the short end of the stick. Adam is the youngest, a camera-wielding future director who's navigating first love, and growing up with his family. Rounding out the family is beloved grandfather Al \"Pops\" Solomon, the wild man of the clan, a shameless Don Juan who's learning as much from his family as he teaches them.</p>",
+    "updated": 1494536522,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/79"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1127337"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1127338"
+        }
+    }
+}, {
+    "id": 80,
+    "url": "http://www.tvmaze.com/shows/80/modern-family",
+    "name": "Modern Family",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy", "Family"],
+    "status": "Running",
+    "runtime": 30,
+    "premiered": "2009-09-23",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Wednesday"]
+    },
+    "rating": {
+        "average": 8.1
+    },
+    "weight": 99,
+    "network": {
+        "id": 3,
+        "name": "ABC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 22622,
+        "thetvdb": 95011,
+        "imdb": "tt1442437"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/102/257290.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/102/257290.jpg"
+    },
+    "summary": "<p>The Pritchett-Dunphy-Tucker clan is a wonderfully large and blended family with Jay Pritchett sitting at the head. By his side is his young, vivacious second wife Gloria, who resists his old-fashioned ways -- an impulse that will become all the more interesting now that he and Gloria have a new baby of their own. This exciting addition will bring more adventures to the family just as Gloria's son, Manny, is about to embark on an adventure of his own as he enters high school. Jay's grown daughter, Claire, and her husband, Phil, also have their son, Luke, heading to high school; their middle daughter, Alex, is full steam ahead on the college track, and the eldest, Haley, is back home figuring out her future. With the kids all growing up, this new chapter means Claire can explore returning to the workforce, which will have its fair share of missteps and victories. And this will be a big year for Claire's brother and Jay's grown son, Mitchell, who alongside his loving partner, Cameron, and daughter Lily, will have a lot of reasons to celebrate. Together these three families give us an honest and often hilarious look into the sometimes warm, sometimes twisted, embrace of the modern family.</p>",
+    "updated": 1494631431,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/80"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1096487"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1096488"
+        }
+    }
+}, {
+    "id": 81,
+    "url": "http://www.tvmaze.com/shows/81/criminal-minds",
+    "name": "Criminal Minds",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Crime", "Thriller"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2005-09-22",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Wednesday"]
+    },
+    "rating": {
+        "average": 8.7
+    },
+    "weight": 99,
+    "network": {
+        "id": 2,
+        "name": "CBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 3171,
+        "thetvdb": 75710,
+        "imdb": "tt0452046"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/77/193187.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/77/193187.jpg"
+    },
+    "summary": "<p><strong>Criminal Minds</strong> revolves around an elite team of FBI profilers who analyze the country's most twisted criminal minds, anticipating their next moves before they strike again. The Behavioral Analysis Unit's most experienced agent is David Rossi, a founding member of the BAU who returns to help the team solve new cases. The team is lead by Special Agent Aaron Hotchner, a strong profiler who is able to gain people's trust and unlock their secrets. Other members Special Agent Derek Morgan, an expert on obsessional crimes; Special Agent Dr. Spencer Reid, a classically misunderstood genius whose social IQ is as low as his intellectual IQ is high; Jennifer \"J.J.\" Jareau, the team's confident unit liaison who was called to a top Pentagon job but returns to the BAU under mysterious circumstances; and Penelope Garcia, a computer wizard who helps research the cases. Each member brings his or her own area of expertise to the table as they pinpoint predators' motivations and identify their emotional triggers in the attempt to stop them.</p>",
+    "updated": 1494595580,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/81"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1101284"
+        }
+    }
+}, {
+    "id": 82,
+    "url": "http://www.tvmaze.com/shows/82/game-of-thrones",
+    "name": "Game of Thrones",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Adventure", "Fantasy"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2011-04-17",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 9.3
+    },
+    "weight": 99,
+    "network": {
+        "id": 8,
+        "name": "HBO",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 24493,
+        "thetvdb": 121361,
+        "imdb": "tt0944947"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/53/132622.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/53/132622.jpg"
+    },
+    "summary": "<p>Based on the bestselling book series <em>A Song of Ice and Fire</em> by George R.R. Martin, this sprawling new HBO drama is set in a world where summers span decades and winters can last a lifetime. From the scheming south and the savage eastern lands, to the frozen north and ancient Wall that protects the realm from the mysterious darkness beyond, the powerful families of the Seven Kingdoms are locked in a battle for the Iron Throne. This is a story of duplicity and treachery, nobility and honor, conquest and triumph. In the <strong>Game of Thrones</strong>, you either win or you die.</p>",
+    "updated": 1493560174,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/82"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/729575"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/937256"
+        }
+    }
+}, {
+    "id": 83,
+    "url": "http://www.tvmaze.com/shows/83/the-simpsons",
+    "name": "The Simpsons",
+    "type": "Animation",
+    "language": "English",
+    "genres": ["Comedy", "Family"],
+    "status": "Running",
+    "runtime": 30,
+    "premiered": "1989-12-17",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 8.6
+    },
+    "weight": 99,
+    "network": {
+        "id": 4,
+        "name": "FOX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 6190,
+        "thetvdb": 71663,
+        "imdb": "tt0096697"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/639.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/639.jpg"
+    },
+    "summary": "<p><strong>The Simpsons</strong> is the longest running scripted show in US television history. It captures the adventures of Homer, Marge, Maggie, Bart and Lisa who are living in a fictional town called Springfield.</p>",
+    "updated": 1494472489,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/83"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1107598"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1107599"
+        }
+    }
+}, {
+    "id": 84,
+    "url": "http://www.tvmaze.com/shows/84/family-guy",
+    "name": "Family Guy",
+    "type": "Animation",
+    "language": "English",
+    "genres": ["Comedy"],
+    "status": "Running",
+    "runtime": 30,
+    "premiered": "1999-01-31",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 8
+    },
+    "weight": 98,
+    "network": {
+        "id": 4,
+        "name": "FOX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 3506,
+        "thetvdb": 75978,
+        "imdb": "tt0182576"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/641.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/641.jpg"
+    },
+    "summary": "<p><strong>Family Guy</strong> follows Peter Griffin the endearingly ignorant dad, and his hilariously offbeat family of middle-class New Englanders in Quahog, RI. Lois is Peter's wife, a stay-at-home mom with no patience for her family's antics. Then there are their kids: 18-year-old Meg is an outcast at school and the Griffin family punching bag; 13-year-old Chris is a socially awkward teen who doesn't have a clue about the opposite sex; and one-year-old Stewie is a diabolically clever baby whose burgeoning sexuality is very much a work in progress. Rounding out the Griffin household is Brian the family dog and a ladies' man who is one step away from AA.</p>",
+    "updated": 1494517248,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/84"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1107605"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1156197"
+        }
+    }
+}, {
+    "id": 86,
+    "url": "http://www.tvmaze.com/shows/86/stalker",
+    "name": "Stalker",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Crime", "Thriller"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2014-10-01",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Wednesday"]
+    },
+    "rating": {
+        "average": 7.8
+    },
+    "weight": 80,
+    "network": {
+        "id": 2,
+        "name": "CBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 41213,
+        "thetvdb": 281697,
+        "imdb": "tt3560094"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/647.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/647.jpg"
+    },
+    "summary": "<p><strong>Stalker</strong> is a psychological thriller about detectives who investigate stalking incidents - including voyeurism, cyber harassment and romantic fixation - for the Threat Assessment Unit of the LAPD. Det. Jack Larsen is a recent transfer to the Unit from New York City's homicide division, whose confidence, strong personality and questionable behavior has landed him in trouble before - but whose past behavior may also prove valuable in his new job. His boss, Lt. Beth Davis, is strong, focused and an expert in the field, driven by her traumatic personal experience as a victim. With the rest of their team, young but eager Det. Ben Caldwell and deceptively smart Det. Janice Lawrence Larsen and Davis assess the threat level of cases and respond before the stalking and intimidation spirals out of control, all while trying to keep their personal obsessions at bay.</p>",
+    "updated": 1493672036,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/86"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/155326"
+        }
+    }
+}, {
+    "id": 87,
+    "url": "http://www.tvmaze.com/shows/87/the-bridge",
+    "name": "The Bridge",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Crime", "Thriller"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2013-07-10",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Wednesday"]
+    },
+    "rating": {
+        "average": 7.5
+    },
+    "weight": 0,
+    "network": {
+        "id": 13,
+        "name": "FX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 33179,
+        "thetvdb": 264085,
+        "imdb": "tt2406376"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/649.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/649.jpg"
+    },
+    "summary": "<p>When the body of a cartel member is found on US soil, Sonya Cross from El Paso PD and her Mexican counterpart, Marco Ruiz must work together to solve the case.</p>",
+    "updated": 1477733762,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/87"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/5828"
+        }
+    }
+}, {
+    "id": 88,
+    "url": "http://www.tvmaze.com/shows/88/reign",
+    "name": "Reign",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Romance", "History"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2013-10-17",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 7.6
+    },
+    "weight": 99,
+    "network": {
+        "id": 5,
+        "name": "The CW",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 34590,
+        "thetvdb": 269602,
+        "imdb": "tt2710394"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/81/204119.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/81/204119.jpg"
+    },
+    "summary": "<p>Hidden between the lines of the history books is the story of Mary Stuart, the young woman the world would come to know as Mary, Queen of Scots. Queen of Scotland since she was six days old, the teenage Mary is already a headstrong monarch - beautiful, passionate, and poised at the very beginning of her tumultuous rise to power. Arriving in France with four close friends as her ladies-in-waiting, Mary has been sent to secure Scotland's strategic alliance by formalizing her arranged engagement to the French king's dashing son, Prince Francis. But the match isn't signed and sealed, it depends more on politics, religion and secret agendas than affairs of the heart. With danger and sexual intrigue around every dark castle corner, Mary rallies her ladies-in-waiting and steels herself, ready to rule the new land and balance the demands of her country and her heart.</p>",
+    "updated": 1494679798,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/88"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1105944"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1105945"
+        }
+    }
+}, {
+    "id": 89,
+    "url": "http://www.tvmaze.com/shows/89/unforgettable",
+    "name": "Unforgettable",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Crime"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2011-09-20",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 7.2
+    },
+    "weight": 0,
+    "network": {
+        "id": 29,
+        "name": "A&E",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 28417,
+        "thetvdb": 248861,
+        "imdb": "tt1842530"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/663.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/663.jpg"
+    },
+    "summary": "<p><strong>Unforgettable</strong> follows Carrie Wells, an enigmatic former police detective with a rare condition that makes her memory so flawless that every place, every conversation, every moment of joy and every heartbreak is forever embedded in her mind. It's not just that she doesn't forget anything - she can't; except for one thing: the details that would help solve her sister's long-ago murder. Carrie has tried to put her past behind her, but she's unexpectedly reunited with her ex-boyfriend and partner, NYPD Detective Al Burns when she consults on a homicide case.</p>",
+    "updated": 1490384508,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/89"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/570271"
+        }
+    }
+}, {
+    "id": 90,
+    "url": "http://www.tvmaze.com/shows/90/haven",
+    "name": "Haven",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Crime", "Supernatural"],
+    "status": "Ended",
+    "runtime": 42,
+    "premiered": "2010-07-09",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Thursday"]
+    },
+    "rating": {
+        "average": 8.2
+    },
+    "weight": 0,
+    "network": {
+        "id": 16,
+        "name": "Syfy",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 24496,
+        "thetvdb": 158661,
+        "imdb": "tt1519931"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/672.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/672.jpg"
+    },
+    "summary": "<p>When FBI Special Agent Audrey Parker is dispatched to the small town of <strong>Haven</strong>, Maine, on a routine case, she soon finds herself increasingly involved in the return of \"The Troubles\", a plague of supernatural afflictions that have occurred in the town at least twice before. With an openness to the possibility of the paranormal, she also finds a more personal link in Haven that may lead her to the mother she has never known.</p><p>She and her partner, police detective Nathan Wuornos, find themselves frequently facing problems caused by both the effects of the Troubles, as well as the activities of town folk who take more drastic measures against those who are Troubled.</p>",
+    "updated": 1483908510,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/90"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/311489"
+        }
+    }
+}, {
+    "id": 91,
+    "url": "http://www.tvmaze.com/shows/91/bad-judge",
+    "name": "Bad Judge",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy", "Family"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2014-10-02",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Thursday"]
+    },
+    "rating": {
+        "average": 7.9
+    },
+    "weight": 0,
+    "network": {
+        "id": 1,
+        "name": "NBC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 35037,
+        "thetvdb": 281595,
+        "imdb": "tt2769470"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/678.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/678.jpg"
+    },
+    "summary": "<p>No excuses, no apologies, no compromises. Wild child Rebecca Wright knows how to have a good time, but she also happens to be one of L.A.'s toughest and most respected criminal court judges. She has a reputation for unorthodox behavior in the courtroom, including creative rulings and saying exactly what's on her mind. Her private life, on the other hand, is anything but innocent. She parties too much and rocks out on the drums in a band with her best friend, Jenny. While there's no shortage of male admirers who would love to spend time with her, she's not ready to settle down... except when an 8-year-old boy - whose parents were put in jail by Rebecca - needs her help. He may, in fact, be the one thing that starts to tame this <strong>Bad Judge</strong>.</p>",
+    "updated": 1488725345,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/91"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/109577"
+        }
+    }
+}, {
+    "id": 92,
+    "url": "http://www.tvmaze.com/shows/92/a-to-z",
+    "name": "A to Z",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy", "Romance"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2014-10-02",
+    "schedule": {
+        "time": "21:30",
+        "days": ["Thursday"]
+    },
+    "rating": {
+        "average": 7
+    },
+    "weight": 0,
+    "network": {
+        "id": 1,
+        "name": "NBC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 37968,
+        "thetvdb": 281588,
+        "imdb": "tt3216682"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/679.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/679.jpg"
+    },
+    "summary": "<p>This is the <strong>A to Z</strong> story of Andrew and Zelda - a pair that almost wasn't - and all that happened from the day they met. Andrew has always been a secret romantic... not above crooning to Celine Dion while driving to work, with dreams of finding \"the one.\" He imagines her to be just like that shimmering beauty he spotted that night in that silver dress at that concert two years ago. Zelda, having grown up with a hippie mom who believed the universe would provide for everything, rebelled into a no-nonsense practical lawyer who prefers the control of online dating. But when a computer glitch sends her a total mismatch, she's asked to come in for an interview at the Internet dating site where Andrew works, and this is where it all begins. Andrew and Zelda meet for the first time and despite their differences, sparks fly. She thinks it's chance. He thinks it's fate. After all, he's convinced she's the shimmering girl in the silver dress. Is it true love forever or just a detour in destiny?</p>",
+    "updated": 1477162055,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/92"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/117558"
+        }
+    }
+}, {
+    "id": 93,
+    "url": "http://www.tvmaze.com/shows/93/parenthood",
+    "name": "Parenthood",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Comedy", "Family"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2010-03-02",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Thursday"]
+    },
+    "rating": {
+        "average": 8.4
+    },
+    "weight": 0,
+    "network": {
+        "id": 1,
+        "name": "NBC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 22586,
+        "thetvdb": 94551,
+        "imdb": "tt1416765"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/685.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/685.jpg"
+    },
+    "summary": "<p><strong><em>\"Parenthood\"</em></strong> is the critically acclaimed one-hour drama inspired by the box office hit of the same name. This reimagined and updated Universal Television/Imagine Entertainment production follows the trials and tribulations of the very large, colorful and imperfect Braverman family. Sarah Braverman is a single mother with two kids - the bright but rebellious Amber who is living on her own, and sullen and sensitive Drew who returns to Berkeley this year.</p>",
+    "updated": 1487814341,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/93"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/109553"
+        }
+    }
+}, {
+    "id": 94,
+    "url": "http://www.tvmaze.com/shows/94/defiance",
+    "name": "Defiance",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Action", "Adventure", "Science-Fiction"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2013-04-15",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Thursday"]
+    },
+    "rating": {
+        "average": 7.6
+    },
+    "weight": 1,
+    "network": {
+        "id": 16,
+        "name": "Syfy",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 30724,
+        "thetvdb": 255326,
+        "imdb": "tt2189221"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/700.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/700.jpg"
+    },
+    "summary": "<p>Set on a future Earth, <strong>Defiance</strong> introduces players and viewers to a world where humans and aliens live together on a planet ravaged by decades of war and transformed by alien terra-forming machines. It centers on Jeb Nolan, the law-keeper in a bustling frontier boomtown that is one of the new world's few oasis of civility and inclusion. Nolan is a former Marine who fought in the alien conflict and suffered the loss of his wife and child in the war. The trauma transformed him into a lone wanderer in the wilds of this new and dangerous world.</p>",
+    "updated": 1491224058,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/94"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/185061"
+        }
+    }
+}, {
+    "id": 95,
+    "url": "http://www.tvmaze.com/shows/95/falling-skies",
+    "name": "Falling Skies",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Science-Fiction"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2011-06-19",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 7.4
+    },
+    "weight": 2,
+    "network": {
+        "id": 14,
+        "name": "TNT",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 26205,
+        "thetvdb": 205281,
+        "imdb": "tt1462059"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/716.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/716.jpg"
+    },
+    "summary": "<p>The series tells the story of the aftermath of a global invasion by several races of extraterrestrials that neutralizes the world's power grid and technology, quickly destroys the combined militaries of all the world's countries, and apparently kills over 90% of the human population within a few days.</p>",
+    "updated": 1491078770,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/95"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/153183"
+        }
+    }
+}, {
+    "id": 96,
+    "url": "http://www.tvmaze.com/shows/96/manhattan-love-story",
+    "name": "Manhattan Love Story",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2014-09-30",
+    "schedule": {
+        "time": "20:30",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 5.2
+    },
+    "weight": 0,
+    "network": {
+        "id": 3,
+        "name": "ABC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 40555,
+        "thetvdb": 281624,
+        "imdb": "tt3514886"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/729.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/729.jpg"
+    },
+    "summary": "<p>Have you ever wondered what your date was thinking? This romantic comedy exposes the differences between men and women through the unfiltered thoughts, and often contradictory actions, of a new couple who have just begun dating.</p>",
+    "updated": 1481919359,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/96"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/32829"
+        }
+    }
+}, {
+    "id": 97,
+    "url": "http://www.tvmaze.com/shows/97/the-biggest-loser",
+    "name": "The Biggest Loser",
+    "type": "Reality",
+    "language": "English",
+    "genres": ["Drama"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2004-10-19",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": null
+    },
+    "weight": 0,
+    "network": {
+        "id": 1,
+        "name": "NBC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 5618,
+        "thetvdb": 75166,
+        "imdb": "tt0429318"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/730.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/730.jpg"
+    },
+    "summary": "<p>NBC's <strong><i>\"The Biggest Loser\"</i></strong> a show known for its incredible weight loss makeovers,\nwill reveal an exciting makeover of its own when the popular series returns on\nMonday, January 4 (9-11 p.m. ET) with new host Bob Harper, a new\n\"Temptation\" theme, an updated state-of-the-art gym, a new logo, fun\nformat changes and a return to the popular team vs. team competition. Dolvett\nQuince and Jen Widerstrom return to train eight contestant teams of two, all\nwith compelling stories. Seven teams (spouses, parent/adult child, siblings,\nrelatives, best friends) will know each other, but one team will be two\nstrangers - former \"Celebrity Apprentice\" contestant and the original\n\"Survivor\" winner, Richard Hatch, and 'The Voice' season two\nsemi-finalist Erin Willett. Having both been in the NBC family previously, the\ntwo share the same goal as the other 14 contestants - to change their lives and\nget healthy. The renovated \"Biggest Loser\" gym, featuring a new\ninterior and exterior branded with the new logo, has modernized equipment to\nhelp contestants better achieve their fitness goals, including eight high-tech\nmonitors on the walls of each side of the gym that will track contestants'\ncalorie burns as well as heart rates. Half of the gym will be dedicated to Team\nDolvett and the other half dedicated to Team Jen. The weigh-in will be very\ndifferent this season with a new look and double scales, so contestants on\nopposing teams can weigh-in side by side, making the weigh-in even more\ncompelling to watch. The contestant house is also getting a whole new look for\nseason 17.</p>",
+    "updated": 1477414697,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/97"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/529021"
+        }
+    }
+}, {
+    "id": 98,
+    "url": "http://www.tvmaze.com/shows/98/scandal",
+    "name": "Scandal",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Thriller"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2012-04-05",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Thursday"]
+    },
+    "rating": {
+        "average": 7.7
+    },
+    "weight": 99,
+    "network": {
+        "id": 3,
+        "name": "ABC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 28398,
+        "thetvdb": 248841,
+        "imdb": "tt1837576"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/87/217517.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/87/217517.jpg"
+    },
+    "summary": "<p>Everyone has secrets… and Olivia Pope has dedicated her life to protecting and defending the public images of the nation's elite by keeping those secrets under wraps. Pope's team are at the top of their game when it comes to getting the job done for their clients, but it becomes apparent that these \"gladiators in suits,\" who specialize in fixing the lives of other people, have trouble fixing those closest at hand -- their own.</p>",
+    "updated": 1494705799,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/98"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1117436"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1117437"
+        }
+    }
+}, {
+    "id": 99,
+    "url": "http://www.tvmaze.com/shows/99/americas-next-top-model",
+    "name": "America's Next Top Model",
+    "type": "Reality",
+    "language": "English",
+    "genres": [],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2003-05-20",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Wednesday"]
+    },
+    "rating": {
+        "average": 6.3
+    },
+    "weight": 1,
+    "network": {
+        "id": 55,
+        "name": "VH1",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 2589,
+        "thetvdb": 71721,
+        "imdb": "tt0363307"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/99/249135.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/99/249135.jpg"
+    },
+    "summary": "<p>Created by supermodel Tyra Banks, <strong>America's Next Top Model</strong> follows a group of young women of various backgrounds, shapes and sizes who live together in a loft and vie for a modeling contract. The show exposes the transformation of everyday young women into potentially fierce supermodels, with participants facing weekly tests that determine who can make the cut. With mentoring by supermodel Tyra Banks and exposure to high-profile fashion-industry gurus, the finalists compete in a highly accelerated modeling boot camp--a crash course to supermodel fame.<br /><br /> Originally hosted by Tyra Banks for it's first 22 seasons, the 23rd season will move from The CW, to VH1 and will be hosted by Rita Ora, who heads up the new judging panel of Ashley Graham, Law Roach and Drew Elliott. </p>",
+    "updated": 1489713389,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/99"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1084865"
+        }
+    }
+}, {
+    "id": 100,
+    "url": "http://www.tvmaze.com/shows/100/blue-bloods",
+    "name": "Blue Bloods",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Crime"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2010-09-24",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 8.7
+    },
+    "weight": 99,
+    "network": {
+        "id": 2,
+        "name": "CBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 25756,
+        "thetvdb": 164981,
+        "imdb": "tt1595859"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/79/197849.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/79/197849.jpg"
+    },
+    "summary": "<p><strong>Blue Bloods </strong> is a drama about a multi-generational family of cops dedicated to New York City law enforcement. Frank Reagan is the New York Police Commissioner and heads both the police force and the Reagan brood. He runs his department as diplomatically as he runs his family, even when dealing with the politics that plagued his unapologetically bold father, Henry, during his stint as Chief. A source of pride and concern for Frank is his eldest son Danny, a seasoned detective, family man and Iraq War vet who on occasion uses dubious tactics to solve cases with his loyal and tough partner, Detective Jackie Curatola. The Reagan women in the family include Erin, a N.Y. Assistant D.A., who also serves as the legal compass for her siblings and father, and single parent to her teenage daughter Nicky; and Linda, Danny's supportive wife. Jamie is the youngest Reagan, a recent grad of Harvard Law and the family's \"golden boy.\" Unable to deny the family tradition, Jamie has decided to give up a lucrative future in law and follow in the family footsteps as a cop.</p>",
+    "updated": 1494092758,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/100"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1113964"
+        }
+    }
+}, {
+    "id": 101,
+    "url": "http://www.tvmaze.com/shows/101/the-good-wife",
+    "name": "The Good Wife",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Crime", "Legal"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2009-09-22",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 8.8
+    },
+    "weight": 89,
+    "network": {
+        "id": 2,
+        "name": "CBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 22755,
+        "thetvdb": 95451,
+        "imdb": "tt1442462"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/59/148162.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/59/148162.jpg"
+    },
+    "summary": "<p><strong> The Good Wife</strong> follows Alicia Florrick, a wife and mother who boldly assumes full responsibility for her family and re-enters the workforce after her husband's very public sex and political corruption scandal lands him in jail. Pushing aside the betrayal and crushing public humiliation caused by her husband Peter, Alicia starts over by pursuing her original career as a defense attorney.</p>",
+    "updated": 1494163571,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/101"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/617860"
+        }
+    }
+}, {
+    "id": 102,
+    "url": "http://www.tvmaze.com/shows/102/boardwalk-empire",
+    "name": "Boardwalk Empire",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Crime"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2010-09-19",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 8.9
+    },
+    "weight": 0,
+    "network": {
+        "id": 8,
+        "name": "HBO",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 23561,
+        "thetvdb": 84947,
+        "imdb": "tt0979432"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/759.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/759.jpg"
+    },
+    "summary": "<p>As the country struggles to cope with the Great Depression and the end of Prohibition looms, Nucky Thompson looks to legitimize himself through alliances with liquor producers, while rivals Lucky Luciano and Meyer Lansky seek to consolidate their power in the wake of Arnold Rothstein's death and eliminate all competition - by any means necessary on <strong>Boardwalk Empire</strong>.</p>",
+    "updated": 1489337665,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/102"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/6977"
+        }
+    }
+}, {
+    "id": 103,
+    "url": "http://www.tvmaze.com/shows/103/law-order-special-victims-unit",
+    "name": "Law & Order: Special Victims Unit",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Crime"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "1999-09-20",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Wednesday"]
+    },
+    "rating": {
+        "average": 9
+    },
+    "weight": 99,
+    "network": {
+        "id": 1,
+        "name": "NBC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 4204,
+        "thetvdb": 75692,
+        "imdb": "tt0203259"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/73/182509.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/73/182509.jpg"
+    },
+    "summary": "<p>In the criminal justice system, sexually-based offenses are considered especially heinous. In New York City, the dedicated detectives who investigate these vicious felonies are members of an elite squad known as the Special Victims Unit. These are their stories.</p>",
+    "updated": 1494523843,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/103"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1071386"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1071387"
+        }
+    }
+}, {
+    "id": 104,
+    "url": "http://www.tvmaze.com/shows/104/dominion",
+    "name": "Dominion",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Action", "Adventure", "Fantasy"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2014-06-19",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Thursday"]
+    },
+    "rating": {
+        "average": 7
+    },
+    "weight": 1,
+    "network": {
+        "id": 16,
+        "name": "Syfy",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 36889,
+        "thetvdb": 277462,
+        "imdb": "tt3079768"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/775.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/775.jpg"
+    },
+    "summary": "<p><strong>Dominion </strong>is an epic supernatural drama set in the near future. Specifically, 25 years after \"The Extinction War,\" when an army of lower angels, assembled by the archangel Gabriel, waged war against mankind. The archangel Michael, turning against his own kind, chose to side with humanity. Rising out of the ashes of this long battle are newly fortified cities which protect human survivors. At the center of the series is the city of Vega, a glistening empire that has formed from the ruins of what was once Las Vegas.</p>",
+    "updated": 1483803457,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/104"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/205969"
+        }
+    }
+}, {
+    "id": 105,
+    "url": "http://www.tvmaze.com/shows/105/from-dusk-till-dawn-the-series",
+    "name": "From Dusk Till Dawn: The Series",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Action", "Crime", "Horror"],
+    "status": "To Be Determined",
+    "runtime": 60,
+    "premiered": "2014-03-11",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 6.4
+    },
+    "weight": 11,
+    "network": {
+        "id": 21,
+        "name": "El Rey Network",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": {
+        "id": 1,
+        "name": "Netflix",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "externals": {
+        "tvrage": 38931,
+        "thetvdb": 276312,
+        "imdb": "tt3337194"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/70/176381.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/70/176381.jpg"
+    },
+    "summary": "<p><strong>From Dusk Till Dawn: The Series</strong> is based on the thrill-ride film, <em>From Dusk Till Dawn</em> is a supernatural crime saga centered around bank robber, Seth Gecko and his violent, unpredictable brother, Richard \"Richie\" Gecko, who are wanted by the FBI and Texas Rangers Earl McGraw and Freddie Gonzalez after a bank heist leaves several people dead. While on the run to Mexico, Seth and Richie encounter former pastor Jacob Fuller and his family, whom they take hostage. Using the family RV to cross the border, chaos ensues when the group detours to a strip club that is populated by vampires. They are forced to fight until dawn in order to get out alive.</p>",
+    "updated": 1486232215,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/105"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/907232"
+        }
+    }
+}, {
+    "id": 106,
+    "url": "http://www.tvmaze.com/shows/106/justified",
+    "name": "Justified",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Crime", "Western"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2010-03-16",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 8.8
+    },
+    "weight": 0,
+    "network": {
+        "id": 13,
+        "name": "FX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 23472,
+        "thetvdb": 134241,
+        "imdb": "tt1489428"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/808.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/808.jpg"
+    },
+    "summary": "<p>Deputy U.S. Marshal Raylan Givens is something of a 19th century-style officer in modern times, whose unconventional enforcement of justice makes him a target with criminals and a problem for his superiors in the U.S. Marshals Service. As a result of an eager but \"justified\" shooting of a Miami fugitive while on assignment in Florida, Givens is reassigned to Lexington, Kentucky, in a district that includes his hometown of Harlan, a rural mining town in the east of the state.</p>",
+    "updated": 1486230915,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/106"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/58231"
+        }
+    }
+}, {
+    "id": 107,
+    "url": "http://www.tvmaze.com/shows/107/bobs-burgers",
+    "name": "Bob's Burgers",
+    "type": "Animation",
+    "language": "English",
+    "genres": ["Comedy"],
+    "status": "Running",
+    "runtime": 30,
+    "premiered": "2011-01-09",
+    "schedule": {
+        "time": "19:30",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 8.7
+    },
+    "weight": 98,
+    "network": {
+        "id": 4,
+        "name": "FOX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 24607,
+        "thetvdb": 194031,
+        "imdb": "tt1561755"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/840.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/840.jpg"
+    },
+    "summary": "<p>The series follows Bob who runs <strong>Bob's Burgers</strong>, with the help of his wife and their three kids. Bob has big ideas about burgers, but the rest of the clan falls short on service. Despite the greasy counters and lousy location, the Belchers are determined to make every \"Grand Re-Re-Re-opening\" a success. Bob's wife, Linda, stands by her man and often does so by bursting into song. Their eldest daughter, 13-year-old Tina has a slight obsession with boys and zombies. Middle child Gene is an aspiring musician with a thirst for life. Louise is the bunny ears-wearing youngest daughter with an off-kilter sense of humor that makes her somewhat of a liability in the kitchen – and with the public.</p>",
+    "updated": 1494434948,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/107"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1117451"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1124554"
+        }
+    }
+}, {
+    "id": 108,
+    "url": "http://www.tvmaze.com/shows/108/mulaney",
+    "name": "Mulaney",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy", "Family"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2014-10-05",
+    "schedule": {
+        "time": "21:30",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 8
+    },
+    "weight": 0,
+    "network": {
+        "id": 4,
+        "name": "FOX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 34928,
+        "thetvdb": 273820,
+        "imdb": "tt2753110"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/846.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/846.jpg"
+    },
+    "summary": "<p>JOHN MULANEY is a 29-year-old comedian working the stand-up circuit and looking for his big break. But life drastically changes when self-centered comedy legend and game show host LOU CANNON hires Mulaney as a writer. Lou may be John's entrée into the world of big-money show business, but he's also a total nightmare. Still, the job represents everything Mulaney thinks he wants. But does he really? And, at what cost? And what does it say about him if he quits? And what does it say about him if he stays? And has Lou had work done? </p>",
+    "updated": 1490482933,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/108"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/122946"
+        }
+    }
+}, {
+    "id": 109,
+    "url": "http://www.tvmaze.com/shows/109/csi-crime-scene-investigation",
+    "name": "CSI: Crime Scene Investigation",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Crime"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2000-10-06",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 8.6
+    },
+    "weight": 87,
+    "network": {
+        "id": 2,
+        "name": "CBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 3183,
+        "thetvdb": 72546,
+        "imdb": "tt0247082"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/887.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/887.jpg"
+    },
+    "summary": "<p><strong>CSI: Crime Scene Investigation</strong> is a fast-paced drama about a team of forensic investigators trained to solve crimes by examining the evidence. They are on the case 24/7, scouring the scene, collecting the irrefutable evidence and finding the missing pieces that will solve the mystery. D.B. Russell, the CSI Supervisor for the grave shift is a family man and scientist, but not a nerd. Son of hippie parents, he's a \"Left Coast\" Sherlock Holmes who devours crime novels and looks at every crime scene as if it were a story waiting to be told.</p><p> Other CSI members include Julie Finlay, the team's Assistant Night Shift Supervisor who worked with D.B. in Seattle; Nick Stokes, the conscience of the team, often driven by his emotional connection to the victim to always get the job done; Sara Sidle, aka Mrs. Grissom, the moral compass of the team who is relentless in her pursuit of criminals; Greg Sanders, once an off-beat tech analyst and now an experienced and intuitive crime solver; and Morgan Brody, an exile from the Los Angeles Crime Lab and the daughter of Undersheriff Ecklie. She's a natural born investigator who still has a lot to learn about politics and family. The CSI team members also work closely with Captain Jim Brass, a seasoned detective and protector of CSI, sometimes to a fault; Dr. Albert Robbins, the ever-professional medical examiner; his wise-cracking assistant, David Phillips; and David Hodges, a tech of many talents who often rubs people the wrong way, but never fails to deliver.</p>",
+    "updated": 1494070567,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/109"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/270033"
+        }
+    }
+}, {
+    "id": 110,
+    "url": "http://www.tvmaze.com/shows/110/gracepoint",
+    "name": "Gracepoint",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Crime", "Mystery"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2014-10-02",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Thursday"]
+    },
+    "rating": {
+        "average": 8
+    },
+    "weight": 0,
+    "network": {
+        "id": 4,
+        "name": "FOX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 39035,
+        "thetvdb": 276396,
+        "imdb": "tt3435532"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/862.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/862.jpg"
+    },
+    "summary": "<p>When a young boy is found dead on an idyllic beach, a major police investigation gets underway in the small California seaside town where the tragedy occurred. Soon deemed a homicide, the case sparks a media frenzy, which throws the boy's family into further turmoil and upends the lives of all of the town's residents. Welcome to GRACEPOINT, a new 10-episode mystery event series based on \"Broadchurch,\" the U.K.'s critically acclaimed hit crime drama.</p>",
+    "updated": 1485452628,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/110"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/32266"
+        }
+    }
+}, {
+    "id": 111,
+    "url": "http://www.tvmaze.com/shows/111/once-upon-a-time",
+    "name": "Once Upon a Time",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Adventure", "Fantasy", "Romance"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2011-10-23",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 7.7
+    },
+    "weight": 100,
+    "network": {
+        "id": 3,
+        "name": "ABC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 28385,
+        "thetvdb": 248835,
+        "imdb": "tt1843230"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/73/183481.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/73/183481.jpg"
+    },
+    "summary": "<p><strong>Once Upon a Time</strong> is Fairy Tale Land. It's filled with magic, monsters and all of the characters we all know from stories growing up. It's real, and so are the people in it. But unlike the \"happily ever after\" you may have heard about, their stories continued, and The Evil Queen cast a Dark Curse over the land....</p><p>This is Storybrooke. It's a quiet, little New England town filled with people who go about their everyday lives with no idea who they really are. The Queen's Curse has trapped them here and placed her in near-complete control. They have no real memories and no real hope.</p>",
+    "updated": 1494613505,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/111"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1077798"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1099162"
+        }
+    }
+}, {
+    "id": 112,
+    "url": "http://www.tvmaze.com/shows/112/south-park",
+    "name": "South Park",
+    "type": "Animation",
+    "language": "English",
+    "genres": ["Comedy"],
+    "status": "Running",
+    "runtime": 30,
+    "premiered": "1997-08-13",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Wednesday"]
+    },
+    "rating": {
+        "average": 8.8
+    },
+    "weight": 94,
+    "network": {
+        "id": 23,
+        "name": "Comedy Central",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 5266,
+        "thetvdb": 75897,
+        "imdb": "tt0121955"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/935.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/935.jpg"
+    },
+    "summary": "<p><strong>South Park</strong> is an adult comedy animation show centred around 4 children in the small town of south park. Its humour is often dark involving satirical elements and mocking current real-life events.</p>",
+    "updated": 1493419202,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/112"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/924472"
+        }
+    }
+}, {
+    "id": 114,
+    "url": "http://www.tvmaze.com/shows/114/survivor",
+    "name": "Survivor",
+    "type": "Reality",
+    "language": "English",
+    "genres": ["Adventure"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2000-05-31",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Wednesday"]
+    },
+    "rating": {
+        "average": 8.8
+    },
+    "weight": 98,
+    "network": {
+        "id": 2,
+        "name": "CBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 5418,
+        "thetvdb": 76733,
+        "imdb": "tt0239195"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/12/31506.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/12/31506.jpg"
+    },
+    "summary": "<p>Eighteen to Twenty castaways will compete against each other on <strong>Survivor</strong>, when the Emmy Award-winning series returns on Wednesdays on CBS Television Network. This edition of SURVIVOR, filmed in Cagayan, a province in the Philippines, will be themed \"Brawn vs. Brains vs. Beauty.\" The groupings of these tribes, each comprised of six castaways, reflect the distinguishing qualities that people bring to the game and test whether there is any truth to the pre-conceived notion that that certain characteristics will help you win the game of SURVIVOR. All castaways will compete to outwit, outplay, outlast and ultimately be crowned Sole Survivor. The show is hosted by Emmy Award winner Jeff Probst.</p>",
+    "updated": 1494678060,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/114"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1085226"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1085227"
+        }
+    }
+}, {
+    "id": 115,
+    "url": "http://www.tvmaze.com/shows/115/king-of-the-hill",
+    "name": "King of the Hill",
+    "type": "Animation",
+    "language": "English",
+    "genres": ["Comedy"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "1997-01-12",
+    "schedule": {
+        "time": "20:30",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 8.4
+    },
+    "weight": 80,
+    "network": {
+        "id": 4,
+        "name": "FOX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 4134,
+        "thetvdb": 73903,
+        "imdb": "tt0118375"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/45/113875.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/45/113875.jpg"
+    },
+    "summary": "<p><strong>King of the Hill</strong> follows the life of Hank Hill, his wife Peggy, their 13-year-old son Bobby, their 18-year-old niece Luanne, her husband Lucky, their newborn baby girl Gracie and his beer guzzling neighborhood buddies, Dale, Bill and Boomhauer.</p>",
+    "updated": 1493830364,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/115"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/8872"
+        }
+    }
+}, {
+    "id": 116,
+    "url": "http://www.tvmaze.com/shows/116/the-mentalist",
+    "name": "The Mentalist",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Crime", "Thriller", "Mystery"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2008-09-23",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 8.7
+    },
+    "weight": 90,
+    "network": {
+        "id": 2,
+        "name": "CBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 18967,
+        "thetvdb": 82459,
+        "imdb": "tt1196946"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/1239.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/1239.jpg"
+    },
+    "summary": "<p>Patrick Jane, an independent consultant with the California Bureau of Investigation (CBI), has a remarkable track record for solving serious crimes by using his razor sharp skills of observation. Within the Bureau, Jane is notorious for his blatant lack of protocol and his semi-celebrity past as a psychic medium, whose paranormal abilities he now admits he feigned. No-nonsense Senior Agent Teresa Lisbon openly resists having Jane in her unit and alternates between reluctantly acknowledging Jane's usefulness and blasting him for his theatrics, narcissism, and dangerous lack of boundaries. Lisbon's team includes agents Kimball Cho, Wayne Rigsby and rookie member Grace Van Pelt, who all think Jane's a loose cannon but admire his charm and knack for clearing cases. </p>",
+    "updated": 1492385907,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/116"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/40943"
+        }
+    }
+}, {
+    "id": 117,
+    "url": "http://www.tvmaze.com/shows/117/star-wars-rebels",
+    "name": "Star Wars Rebels",
+    "type": "Animation",
+    "language": "English",
+    "genres": ["Action", "Adventure", "Science-Fiction"],
+    "status": "Running",
+    "runtime": 30,
+    "premiered": "2014-10-03",
+    "schedule": {
+        "time": "11:00",
+        "days": ["Saturday"]
+    },
+    "rating": {
+        "average": 7.7
+    },
+    "weight": 96,
+    "network": {
+        "id": 25,
+        "name": "Disney XD",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": {
+        "id": 123,
+        "name": "WATCH Disney XD",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "externals": {
+        "tvrage": 35995,
+        "thetvdb": 283468,
+        "imdb": "tt2930604"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/26/66846.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/26/66846.jpg"
+    },
+    "summary": "<p><strong>Star Wars Rebels</strong>, set five years before the events of Star Wars: Episode IV - A New Hope, tells the story of the Rebellion's beginnings while the Empire spreads tyranny through the galaxy.</p>",
+    "updated": 1493142543,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/117"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1102806"
+        }
+    }
+}, {
+    "id": 118,
+    "url": "http://www.tvmaze.com/shows/118/house",
+    "name": "House",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Mystery", "Medical"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2004-11-16",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 9
+    },
+    "weight": 84,
+    "network": {
+        "id": 4,
+        "name": "FOX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 3908,
+        "thetvdb": 73255,
+        "imdb": "tt0412142"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/43/109520.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/43/109520.jpg"
+    },
+    "summary": "<p>Sink your teeth into meaty drama and intrigue with <strong>House</strong>, FOX's take on mystery, where the villain is a medical malady and the hero is an irreverent, controversial doctor who trusts no one, least of all his patients.</p>",
+    "updated": 1493505997,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/118"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/9206"
+        }
+    }
+}, {
+    "id": 120,
+    "url": "http://www.tvmaze.com/shows/120/transparent",
+    "name": "Transparent",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Comedy"],
+    "status": "Running",
+    "runtime": 30,
+    "premiered": "2014-09-26",
+    "schedule": {
+        "time": "",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 7.6
+    },
+    "weight": 90,
+    "network": null,
+    "webChannel": {
+        "id": 3,
+        "name": "Amazon Prime",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "externals": {
+        "tvrage": 37044,
+        "thetvdb": 278334,
+        "imdb": "tt3502262"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/34/86184.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/34/86184.jpg"
+    },
+    "summary": "<p>In <strong>Transparent</strong> an LA family with serious boundary issues have their past and future unravel when a dramatic admission causes everyone's secrets to spill out.</p>",
+    "updated": 1493575373,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/120"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/924207"
+        }
+    }
+}, {
+    "id": 122,
+    "url": "http://www.tvmaze.com/shows/122/nikita",
+    "name": "Nikita",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Action"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2010-09-09",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 8.1
+    },
+    "weight": 0,
+    "network": {
+        "id": 5,
+        "name": "The CW",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 25189,
+        "thetvdb": 164301,
+        "imdb": "tt1592154"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/1366.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/1366.jpg"
+    },
+    "summary": "<p>When she was a deeply troubled teenager, Nikita was rescued from death row by a secret U.S. agency known only as Division, who trained her as a spy and assassin. Nikita was eventually betrayed by the only people she thought she could trust. Now, after three years in hiding, Nikita is seeking retribution and making it clear to her former boss, Percy and her former friends Michael and Birkhoff that she will stop at nothing to expose and destroy their covert operation.</p>",
+    "updated": 1486928045,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/122"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/10139"
+        }
+    }
+}, {
+    "id": 123,
+    "url": "http://www.tvmaze.com/shows/123/lost",
+    "name": "Lost",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Adventure", "Supernatural"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2004-09-22",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 8.6
+    },
+    "weight": 92,
+    "network": {
+        "id": 3,
+        "name": "ABC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 4284,
+        "thetvdb": 73739,
+        "imdb": "tt0411008"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/1389.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/1389.jpg"
+    },
+    "summary": "<p>Out of the blackness, the first thing Jack senses is pain. Then burning sun. A Bamboo forest. Smoke. Screams. With a rush comes the horrible awareness that the plane he was on tore apart in mid-air and crashed on a Pacific island. From there it's a blur, as his doctor's instinct kicks in: people need his help.</p><p>Stripped of everything, the 48 survivors scavenge what they can from the plane for their survival. Some panic. Some pin their hopes on rescue. A few find inner strength they never knew they had -- like Kate, who, with no medical training, suddenly finds herself suturing the doctor's wounds. Hurley - a man with a warm sense of humor despite the desperate situation - does his best to keep his cool as he helps those around him to survive. Charlie is a faded rock star who harbors a painful secret. Sayid is a Middle Eastern man who must wrestle with the racial profiling directed at him by some of his fellow survivors. Jin and Sun are a Korean couple whose traditions, values and language are foreign, and thus causes much to get lost in the translation. Sawyer has an air of danger surrounding him, and his intense sense of mistrust for everyone around him could prove to be fatal to his fellow castaways. Michael has just gained custody of his nine-year-old son, Walt, after the death of his ex-wife - they are a father and son who don't even know each other. Locke is a mysterious man who keeps to himself, and who harbors a deeper connection to the island than any of the others. Self-centered Shannon - who actually gives herself a pedicure amid the chaos - and her estranged controlling brother, Boone , constantly bicker and must learn to get along if they are to survive. And young Claire is eight months pregnant and ill-prepared for the hardships of motherhood - especially on a deserted island.</p>",
+    "updated": 1493983525,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/123"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/10260"
+        }
+    }
+}, {
+    "id": 124,
+    "url": "http://www.tvmaze.com/shows/124/2-broke-girls",
+    "name": "2 Broke Girls",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2011-09-19",
+    "schedule": {
+        "time": "21:30",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 7.6
+    },
+    "weight": 97,
+    "network": {
+        "id": 2,
+        "name": "CBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 28416,
+        "thetvdb": 248741,
+        "imdb": "tt1845307"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/52/130673.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/52/130673.jpg"
+    },
+    "summary": "<p><strong>2 Broke Girls</strong> is a comedy about two young women waitressing at a greasy spoon diner who strike up an unlikely friendship in the hopes of launching a successful business - if only they can raise the cash. Sassy, streetwise Max Black works two jobs just to get by, one of which is waiting tables during the night shift at the retro-hip Williamsburg Diner. Sophisticated Caroline Channing is an uptown trust fund princess who's having a run of bad luck that forces her to reluctantly give waitressing a shot. At first, Max sees Caroline as yet another in a long line of inept servers she must cover for, but she's surprised to find that Caroline has as much substance as she does style.</p><p>When Caroline discovers Max's knack for baking amazing cupcakes, she sees a lucrative future for them, but first they need to raise the start-up money. While they save their tips, they'll stay at the restaurant, working with Oleg, an overly flirtatious Russian cook; Earl, a 75-year-old kool-kat cashier; and Han Lee, the new, eager-to-please owner of the diner. Working together, these two broke girls living in one expensive city might just find the perfect recipe for their big break.</p>",
+    "updated": 1494639021,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/124"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1107556"
+        }
+    }
+}, {
+    "id": 125,
+    "url": "http://www.tvmaze.com/shows/125/selfie",
+    "name": "Selfie",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy", "Romance"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2014-09-30",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 7.4
+    },
+    "weight": 0,
+    "network": {
+        "id": 3,
+        "name": "ABC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 40594,
+        "thetvdb": 279529,
+        "imdb": "tt3549044"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/1756.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/1756.jpg"
+    },
+    "summary": "<p>Eliza Dooley has 263,000 followers who hang on to her every post, tweet and selfie. But one lonely day, she has a revelation: being friended is not the same as having actual friends. She asks marketing guru Henry to 'rebrand' her self-obsessed reputation and teach her how to connect with people in the real world. Loosely based on <em>My Fair Lady</em>, <strong><em>\"Selfie\"</em></strong> explores the modern struggles of Eliza and Henry, as he tries to teach her how to live life offline - whether she 'likes' it or not.</p>",
+    "updated": 1471888063,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/125"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/100845"
+        }
+    }
+}, {
+    "id": 126,
+    "url": "http://www.tvmaze.com/shows/126/mom",
+    "name": "Mom",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy", "Family"],
+    "status": "Running",
+    "runtime": 30,
+    "premiered": "2013-09-23",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Thursday"]
+    },
+    "rating": {
+        "average": 7.6
+    },
+    "weight": 98,
+    "network": {
+        "id": 2,
+        "name": "CBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 33829,
+        "thetvdb": 266967,
+        "imdb": "tt2660806"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/47/119089.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/47/119089.jpg"
+    },
+    "summary": "<p>Christy is a single mom who, after years of questionable choices, is now sober and trying to get her life on track. She's tested daily by her newly sober mother, Bonnie, who is trying to make up for all the ways she's let Christy down. Christy is further challenged by her relationships with her own kids. Her daughter Violet is engaged to a man twice her age and her ten-year-old son, Roscoe, would rather live with his father Baxter, a former slacker who has only recently gotten himself together. To help her stay sober, Christy relies on her support system from AA, comprised of her sponsor Marjorie, her wealthy sponsee, Jill, and her emotional friend, Wendy. Christy tries to remain positive as she attempts to overcome her past and build a better future, but with her dysfunctional family and life's many setbacks, it's always an uphill battle.</p>",
+    "updated": 1494608524,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/126"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1107590"
+        }
+    }
+}, {
+    "id": 127,
+    "url": "http://www.tvmaze.com/shows/127/the-affair",
+    "name": "The Affair",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Romance"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2014-10-12",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 7.6
+    },
+    "weight": 1,
+    "network": {
+        "id": 9,
+        "name": "Showtime",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 36214,
+        "thetvdb": 270439,
+        "imdb": "tt2699110"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/84/211424.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/84/211424.jpg"
+    },
+    "summary": "<p>At once deeply observed and intriguingly elusive, <strong>The Affair</strong> explores the emotional effects of an extramarital relationship.</p><p>Noah is a New York City schoolteacher and novelist who is happily married, but resents his dependence on his wealthy father-in-law. Alison is a young waitress trying to piece her life and marriage back together in the wake of a tragedy. The provocative drama unfolds when Alison and Noah meet in Montauk at the end of Long Island.</p>",
+    "updated": 1490390743,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/127"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/986148"
+        }
+    }
+}, {
+    "id": 128,
+    "url": "http://www.tvmaze.com/shows/128/jane-the-virgin",
+    "name": "Jane the Virgin",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Comedy", "Romance"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2014-10-13",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 8
+    },
+    "weight": 97,
+    "network": {
+        "id": 5,
+        "name": "The CW",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 36552,
+        "thetvdb": 281621,
+        "imdb": "tt3566726"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/53/132727.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/53/132727.jpg"
+    },
+    "summary": "<p>When Jane Villanueva was a young girl, her grandmother, Alba, convinced her of two things: telenovelas are the highest form of entertainment, and women must protect their virginity at all costs. Now age 23, Jane is a driven young woman studying to become a teacher, nursing a dream to be a writer, and supporting herself with a job at a hot new Miami hotel. All the years of watching telenovelas with the two women who raised her - her sexy, young-at-heart mother, Xiomara, and her still-devout grandmother, Alba - have given Jane a slightly unrealistic view of romance. Still, she is determined not to make the same mistake her mother made - becoming an unwed mother at 16. Jane has managed to find a wonderful fiancé: a handsome, hard-working detective named Michael, who loves her enough to accept her detailed timeline for their future together and even her insistence on \"saving herself\" until they're married. All of Jane's meticulous life plans are turned upside down, however, when she sees her doctor for a routine check-up and is accidentally artificially inseminated with a specimen meant for the patient in the next room. Unbeknownst to her, the specimen belongs to Rafael, a reformed playboy and cancer survivor, who is not only the new owner of the hotel where Jane works but also a former summer crush of hers. A few weeks later, the unsuspecting Jane is faced with the most important decisions of her life. Will she continue with the pregnancy? How can she explain the situation to her fiancé and family? And what should she do about the wishes of the biological father, Rafael, and his scheming wife Petra? Though she has always tried to be the good girl who does the right thing, Jane's life has suddenly become as dramatic and complicated as the telenovelas she has always loved.</p>",
+    "updated": 1494359165,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/128"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1105954"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1105955"
+        }
+    }
+}, {
+    "id": 129,
+    "url": "http://www.tvmaze.com/shows/129/marry-me",
+    "name": "Marry Me",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2014-10-14",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 6.3
+    },
+    "weight": 0,
+    "network": {
+        "id": 1,
+        "name": "NBC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 37061,
+        "thetvdb": 281589,
+        "imdb": "tt3460454"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/1836.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/1836.jpg"
+    },
+    "summary": "<p>Six years ago, Annie and Jake bonded over their mutual love of nachos and they've been inseparable ever since. Now, after returning from a romantic two-week island vacation, Jake's all set to pop the question. Before he can ask, though, Annie lets loose on Jake for his inability to commit. She was expecting him to \"put a ring on it\" in paradise and now Jake's perfect proposal is ruined. Not wanting to spend the next 60 years talking about that mess of a proposal, Jake and Annie decide to hold off on the engagement until they can do it right. Yet if history tells us anything, it's when we really want things to go right that they all tend to go wrong. The only thing we know for sure is these two are destined to be together whether they can get it together or not.</p>",
+    "updated": 1483721070,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/129"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/545023"
+        }
+    }
+}, {
+    "id": 130,
+    "url": "http://www.tvmaze.com/shows/130/two-and-a-half-men",
+    "name": "Two and a Half Men",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2003-09-22",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Thursday"]
+    },
+    "rating": {
+        "average": 6.8
+    },
+    "weight": 0,
+    "network": {
+        "id": 2,
+        "name": "CBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 6454,
+        "thetvdb": 72227,
+        "imdb": "tt0369179"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/1867.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/1867.jpg"
+    },
+    "summary": "<p>Charlie is a well-to-do bachelor with a house at the beach, a Jaguar in the front, and an easy way with women. His casual Malibu lifestyle is interrupted when his tightly wound brother Alan, who's facing a divorce, and his son Jake, come to live with him. Together, these two and a half men confront the challenges of growing up; finally. Complicating matters are the brothers' self-obsessed, controlling mother, Evelyn, Alan's estranged wife, Judith and Charlie's crazy neighbor Rose, who wants to be a part of his life and is willing to do anything to be around. After the death of his brother, Alan Harper meets and befriends a lonely young man named Walden Schmidt who turns out to be a billionaire. Unable to afford his brother's home, Alan sells Walden the house, and as a way of showing his gratitude, Walden allows Alan and his son Jake to move in with him.</p>",
+    "updated": 1486893808,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/130"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/58239"
+        }
+    }
+}, {
+    "id": 131,
+    "url": "http://www.tvmaze.com/shows/131/about-a-boy",
+    "name": "About a Boy",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Comedy", "Romance"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2014-02-22",
+    "schedule": {
+        "time": "21:30",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 6.5
+    },
+    "weight": 0,
+    "network": {
+        "id": 1,
+        "name": "NBC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 33032,
+        "thetvdb": 269593,
+        "imdb": "tt2666270"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/1880.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/1880.jpg"
+    },
+    "summary": "<p>Will Freeman lives a charmed existence as the ultimate man-child. After writing a hit song, he was granted a life of free time, free love and freedom from financial woes. He's single, unemployed and loving it. So imagine his surprise when Fiona, a needy, single mom and her oddly charming 11-year-old son Marcus move in next door and disrupt his perfect world.</p>",
+    "updated": 1486239563,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/131"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/277973"
+        }
+    }
+}, {
+    "id": 132,
+    "url": "http://www.tvmaze.com/shows/132/the-millers",
+    "name": "The Millers",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2013-10-03",
+    "schedule": {
+        "time": "20:30",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 6.4
+    },
+    "weight": 0,
+    "network": {
+        "id": 2,
+        "name": "CBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 35810,
+        "thetvdb": 269644,
+        "imdb": "tt2737290"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/1886.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/1886.jpg"
+    },
+    "summary": "<p><strong>The Millers</strong> follows Nathan Miller, a recently \t\t\tdivorced local roving news reporter looking forward to living the \t\t\tsingles life until his parents' marital problems unexpectedly derail \t\t\this plans. After Nathan finally breaks the news of his divorce to his \t\t\tparents Carol and Tom, his father is inspired to follow suit and \t\t\tstuns the family when he leaves his wife of 43 years. Already in \t\t\tshock, Nathan is even more aghast when his meddlesome mom decides to \t\t\tmove in with him. Meanwhile, his absent-minded dad imposes upon \t\t\tNathan's sister Debbie, her husband Adam and their daughter. Nathan's \t\t\tbest friend and news cameraman Ray was excited to be Nathan's wingman \t\t\tin the dating scene, but Carol manages to even cramp his style. Now, \t\t\tas Nathan and his sister settle in with their truly impossible \t\t\tparents, they both wonder just how long the aggravating adjustment \t\t\tperiod is going to last.</p>",
+    "updated": 1479439913,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/132"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/183926"
+        }
+    }
+}, {
+    "id": 133,
+    "url": "http://www.tvmaze.com/shows/133/elementary",
+    "name": "Elementary",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Crime", "Mystery"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2012-09-27",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 8.3
+    },
+    "weight": 100,
+    "network": {
+        "id": 2,
+        "name": "CBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 30750,
+        "thetvdb": 255316,
+        "imdb": "tt2191671"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/1888.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/1888.jpg"
+    },
+    "summary": "<p><strong>Elementary </strong>is a modern-day take on the classic Sherlock Holmes story about a crime-solving duo that cracks the NYPD's most impossible cases. Following his fall from grace in London and a stint in rehab, eccentric Sherlock escapes to Manhattan where his wealthy father forces him to live with his worst nightmare - a sober companion, Dr. Watson.</p>",
+    "updated": 1494678595,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/133"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1049787"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1049788"
+        }
+    }
+}, {
+    "id": 134,
+    "url": "http://www.tvmaze.com/shows/134/heroes",
+    "name": "Heroes",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Action", "Science-Fiction"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2006-09-25",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 7.8
+    },
+    "weight": 0,
+    "network": {
+        "id": 1,
+        "name": "NBC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 8172,
+        "thetvdb": 79501,
+        "imdb": "tt0813715"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/1904.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/1904.jpg"
+    },
+    "summary": "<p>This epic chronicles the lives of ordinary people who discover they possess extraordinary abilities. As a total eclipse casts a shadow across the globe, viewers follow a genetics professor in India whose father's disappearance leads him to uncover a secret theory<i>—</i>there are people with super powers living among us. A young dreamer tries to convince his politician brother that he can fly. A high school cheerleader learns that she is totally indestructible. A Las Vegas stripper, struggling to make ends meet to support her young son, uncovers that her mirror image has a secret. A prison inmate mysteriously finds himself waking up outside of his cell. A gifted artist, whose drug addiction is destroying his life and the relationship with his girlfriend, can paint the future. A down-on-his-luck beat cop can hear people's thoughts, including the secrets of a captured terrorist. In Japan, a young man develops a way to stop time through sheer will power. Their ultimate destiny is nothing less than saving the world.</p>",
+    "updated": 1490697007,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/134"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/10817"
+        }
+    }
+}, {
+    "id": 136,
+    "url": "http://www.tvmaze.com/shows/136/the-mccarthys",
+    "name": "The McCarthys",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy", "Family"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2014-10-30",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Saturday"]
+    },
+    "rating": {
+        "average": 7
+    },
+    "weight": 0,
+    "network": {
+        "id": 2,
+        "name": "CBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 34589,
+        "thetvdb": 281625,
+        "imdb": "tt3434378"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/1900.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/1900.jpg"
+    },
+    "summary": "<p><strong>The McCarthys</strong> is a multi-camera comedy about a close-knit, \t\t\tsports-crazed Boston family whose somewhat athletically challenged \t\t\tson, Ronny, is chosen by his father to be his assistant high school \t\t\tbasketball coach, much to the surprise of his more qualified \t\t\tsiblings. Ronny wants nothing more than to move away, join the \t\t\tsingles scene and find a partner. His distraught mother, Marjorie is \t\t\tnot upset that her favorite son is gay, but that he wants to leave \t\t\tBoston and his family.</p><p>Ronny's plans change, however, when his \t\t\tpolitically incorrect and outspoken father, Arthur stuns everyone \t\t\twith his choice for an assistant. Touched by his father's offer, \t\t\tRonny embarks on a completely different future and he can be sure \t\t\tthat his loving family, including his twin brothers Sean and Gerard \t\t\tand his sister Jackie, are going to have a very vocal opinion about \t\t\tit.</p>",
+    "updated": 1479233148,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/136"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/122990"
+        }
+    }
+}, {
+    "id": 137,
+    "url": "http://www.tvmaze.com/shows/137/cristela",
+    "name": "Cristela",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy", "Legal"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2014-10-10",
+    "schedule": {
+        "time": "20:30",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 6.5
+    },
+    "weight": 0,
+    "network": {
+        "id": 3,
+        "name": "ABC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 37356,
+        "thetvdb": 281616,
+        "imdb": "tt3729144"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/1932.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/1932.jpg"
+    },
+    "summary": "<p>Cristela's dream of becoming a lawyer is something her traditional Mexican-American family doesn't quite understand. She's entering her sixth year of law school after juggling home obligations and working multiple jobs to pay her way.</p>",
+    "updated": 1484402697,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/137"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/151446"
+        }
+    }
+}, {
+    "id": 138,
+    "url": "http://www.tvmaze.com/shows/138/the-leftovers",
+    "name": "The Leftovers",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Fantasy", "Science-Fiction", "Thriller", "Mystery"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2014-06-29",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 7.8
+    },
+    "weight": 100,
+    "network": {
+        "id": 8,
+        "name": "HBO",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 34506,
+        "thetvdb": 269689,
+        "imdb": "tt2699128"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/107/267799.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/107/267799.jpg"
+    },
+    "summary": "<p>Three years after millions of people - some 2% of the world's population - vanished into thin air, residents of Mapleton, NY weigh the pros and cons of a \"Heroes Day\" tribute to the local \"Departed.\" Attempting to maintain a sense of normalcy in his strained community, police chief Kevin Garvey faces additional challenges at home with his daughter, Jill, who's lost in a cloud of apathy with her friend Aimee, and son, Tom, who has gravitated to a cult led by the charismatic Holy Wayne. Also of concern is a silent, white-clad group of chain-smoking men and women called the Guilty Remnant, who team up in pairs to stake out people and places around town. As tension in Mapleton escalates, the lives of Laurie, an unexpected member of the Guilty Remnant, and Meg, a recently engaged young woman, converge.</p>",
+    "updated": 1494264199,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/138"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1101228"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1107140"
+        }
+    }
+}, {
+    "id": 139,
+    "url": "http://www.tvmaze.com/shows/139/girls",
+    "name": "Girls",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Romance"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2012-04-15",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 6.6
+    },
+    "weight": 99,
+    "network": {
+        "id": 8,
+        "name": "HBO",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 30124,
+        "thetvdb": 220411,
+        "imdb": "tt1723816"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/31/78286.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/31/78286.jpg"
+    },
+    "summary": "<p>This Emmy winning series is a comic look at the assorted humiliations and rare triumphs of a group of girls in their 20s.</p>",
+    "updated": 1492431290,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/139"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1079686"
+        }
+    }
+}, {
+    "id": 140,
+    "url": "http://www.tvmaze.com/shows/140/looking",
+    "name": "Looking",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Romance"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2014-01-19",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 7.2
+    },
+    "weight": 0,
+    "network": {
+        "id": 8,
+        "name": "HBO",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 37412,
+        "thetvdb": 274337,
+        "imdb": "tt2581458"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/1961.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/1961.jpg"
+    },
+    "summary": "<p><strong>Looking</strong> offers up the unfiltered experiences of three close friends living - and loving - in modern-day San Francisco. Friendship may bind them, but each is at a markedly different point in his journey: Patrick is the 29-year-old video game designer getting back into the dating world in the wake of his ex's engagement; aspiring artist Agustín, 31, is questioning the idea of monogamy amid a move to domesticate with his boyfriend; and the group's oldest member - longtime waiter Dom, 39 - is facing middle age with romantic and professional dreams still unfulfilled.</p><p>The trio's stories intertwine and unspool dramatically as they search for happiness and intimacy in an age of unparalleled choices - and rights - for gay men. Also important to the ‘Looking' mix is the progressive, unpredictable, sexually open culture of the Bay Area, with real San Francisco locations serving as a backdrop for the group's lives. Rounding out the ‘Looking' world are a bevy of dynamic gay men including Kevin, Lynn, and Richie, as well as a wide-range of supporting characters like Dom's roommate Doris, Agustín's boyfriend Frank, and Patrick's co-worker Owen.</p>",
+    "updated": 1479174492,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/140"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/131209"
+        }
+    }
+}, {
+    "id": 141,
+    "url": "http://www.tvmaze.com/shows/141/getting-on",
+    "name": "Getting On",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy", "Medical"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2013-11-24",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 8.3
+    },
+    "weight": 0,
+    "network": {
+        "id": 8,
+        "name": "HBO",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 35136,
+        "thetvdb": 270735,
+        "imdb": "tt2342652"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/1970.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/1970.jpg"
+    },
+    "summary": "<p>From creators Mark V. Olsen and Will Scheffer, the series follows the daily lives of nurses and doctors as they struggle with the darkly comic realities of caring for the elderly in an overwhelmed healthcare system, skewering the petty bureaucracies of modern medical practice in America.</p>",
+    "updated": 1467788132,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/141"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/479291"
+        }
+    }
+}, {
+    "id": 142,
+    "url": "http://www.tvmaze.com/shows/142/veep",
+    "name": "Veep",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy"],
+    "status": "Running",
+    "runtime": 30,
+    "premiered": "2012-04-22",
+    "schedule": {
+        "time": "22:30",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 8.3
+    },
+    "weight": 98,
+    "network": {
+        "id": 8,
+        "name": "HBO",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 28149,
+        "thetvdb": 237831,
+        "imdb": "tt1759761"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/53/132718.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/53/132718.jpg"
+    },
+    "summary": "<p>Former Senator Selina Meyer has accepted the call to serve as Vice President of the United States. The job is nothing like she imagined and everything she was warned about. <strong>Veep</strong> follows Meyer and her staff as they attempt to make their mark and leave a lasting legacy, without getting tripped up in the day-to-day political games that define Washington.</p>",
+    "updated": 1494259175,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/142"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1125419"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1125420"
+        }
+    }
+}, {
+    "id": 143,
+    "url": "http://www.tvmaze.com/shows/143/silicon-valley",
+    "name": "Silicon Valley",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy"],
+    "status": "Running",
+    "runtime": 30,
+    "premiered": "2014-04-06",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 8.6
+    },
+    "weight": 100,
+    "network": {
+        "id": 8,
+        "name": "HBO",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 33759,
+        "thetvdb": 277165,
+        "imdb": "tt2575988"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/104/261725.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/104/261725.jpg"
+    },
+    "summary": "<p>In the high-tech gold rush of modern <em>Silicon Valley</em>, the people most qualified to succeed are the least capable of handling success. Mike Judge brings his irreverent brand of humor, and his own experiences working in <em>Silicon Valley</em>, to the award-winning comedy now entering its third season. </p>",
+    "updated": 1494321412,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/143"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1119032"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1119033"
+        }
+    }
+}, {
+    "id": 144,
+    "url": "http://www.tvmaze.com/shows/144/the-comeback",
+    "name": "The Comeback",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy"],
+    "status": "To Be Determined",
+    "runtime": 30,
+    "premiered": "2005-06-05",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 7.6
+    },
+    "weight": 51,
+    "network": {
+        "id": 8,
+        "name": "HBO",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 5689,
+        "thetvdb": 75383,
+        "imdb": "tt0434672"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/1995.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/1995.jpg"
+    },
+    "summary": "<p>The limited comedy series stars Lisa Kudrow as the embattled Valerie Cherish, a fading TV \"It Girl\" who was once so desperate to stay in the spotlight that she allowed cameras to follow her every move as she appeared on a new sitcom - with disastrous results. Now, it's ten years later, and Valerie thinks she has it all figured out this time. She doesn't.</p>",
+    "updated": 1493533031,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/144"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/57793"
+        }
+    }
+}, {
+    "id": 145,
+    "url": "http://www.tvmaze.com/shows/145/house-of-lies",
+    "name": "House of Lies",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2012-01-08",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 7.7
+    },
+    "weight": 0,
+    "network": {
+        "id": 9,
+        "name": "Showtime",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 27561,
+        "thetvdb": 247909,
+        "imdb": "tt1797404"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/2003.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/2003.jpg"
+    },
+    "summary": "<p>Charming, fast talking Marty Kaan and his crack team of management consultants know how to play the corporate game better than anyone, by using every dirty trick in the book to woo powerful CEOs and close huge deals. In the board rooms, barrooms, and bedrooms of the power elite, corruption is business as usual and everyone's out for themselves first. Nothing is sacred in this scathing, irreverent satire of corporate America today.</p>",
+    "updated": 1484764890,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/145"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/678040"
+        }
+    }
+}, {
+    "id": 146,
+    "url": "http://www.tvmaze.com/shows/146/episodes",
+    "name": "Episodes",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy"],
+    "status": "Running",
+    "runtime": 30,
+    "premiered": "2011-01-09",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 7.7
+    },
+    "weight": 94,
+    "network": {
+        "id": 9,
+        "name": "Showtime",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 23953,
+        "thetvdb": 123581,
+        "imdb": "tt1582350"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/2013.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/2013.jpg"
+    },
+    "summary": "<p>Matt LeBlanc stars as Matt LeBlanc in EPISODES, the hilarious comedy series about remaking a comedy series. When husband and wife writing team Sean and Beverly set out to reproduce their British TV hit for an American network, all of their worst fears come true as Hollywood lives up to its reputation for absurdity. Not only does the network cast Matt LeBlanc in the starring role, but Matt takes the lead in deviously twisting their beloved series into a terrible cliché, while testing the couple's marriage with diversions and temptations.</p>",
+    "updated": 1493506837,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/146"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/58281"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1126353"
+        }
+    }
+}, {
+    "id": 147,
+    "url": "http://www.tvmaze.com/shows/147/nurse-jackie",
+    "name": "Nurse Jackie",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Comedy", "Thriller"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2009-06-08",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 8.3
+    },
+    "weight": 50,
+    "network": {
+        "id": 9,
+        "name": "Showtime",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 19651,
+        "thetvdb": 95731,
+        "imdb": "tt1190689"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/2021.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/2021.jpg"
+    },
+    "summary": "<p>Every day is a matter of life and death in a hectic New York City hospital, but for <strong>Nurse Jackie</strong> that's the easiest part. Between chronic back pain that won't quit, and a personal life on the constant edge of collapse, it's going to take a white lie here, a bent rule there, and a handful of secret strategies to relieve the pain, and stay one step ahead of total disaster.</p>",
+    "updated": 1494272319,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/147"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/155560"
+        }
+    }
+}, {
+    "id": 148,
+    "url": "http://www.tvmaze.com/shows/148/web-therapy",
+    "name": "Web Therapy",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2011-07-19",
+    "schedule": {
+        "time": "23:00",
+        "days": ["Wednesday"]
+    },
+    "rating": {
+        "average": 7
+    },
+    "weight": 0,
+    "network": {
+        "id": 9,
+        "name": "Showtime",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 28687,
+        "thetvdb": 250078,
+        "imdb": "tt1930123"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/2036.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/2036.jpg"
+    },
+    "summary": "<p>Fiona Wallice is a therapist with little patience for her patients. Tired of hearing about people's problems for fifty long minutes, she devises a new treatment, the three-minute video chat. And still, the sessions end up being largely about her. If she's your therapist, you've got problems. Emmy Award® winner Lisa Kudrow co-created, produces and stars in this outrageous therapeutic send-up. Originally produced as webisodes, WEB THERAPY features an A-list guest cast who, along with Kudrow, improvise their performances with hilarious results.</p>",
+    "updated": 1462180440,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/148"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/41116"
+        }
+    }
+}, {
+    "id": 149,
+    "url": "http://www.tvmaze.com/shows/149/masters-of-sex",
+    "name": "Masters of Sex",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2013-09-29",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 7.1
+    },
+    "weight": 1,
+    "network": {
+        "id": 9,
+        "name": "Showtime",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 32002,
+        "thetvdb": 261557,
+        "imdb": "tt2137109"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/72/181732.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/72/181732.jpg"
+    },
+    "summary": "<p><strong>Masters of Sex</strong> is a drama that portrays the real-life pioneers of the science of human sexuality, William Masters and Virginia Johnson. The series chronicles the unusual lives, romance, and pop culture trajectory of Masters and Johnson. Their research touched off the sexual revolution and took them from a midwestern teaching hospital in St. Louis to the cover of Time magazine and nearly a dozen appearances on Johnny Carson's couch.</p>",
+    "updated": 1485462050,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/149"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/882606"
+        }
+    }
+}, {
+    "id": 150,
+    "url": "http://www.tvmaze.com/shows/150/shameless",
+    "name": "Shameless",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Comedy"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2011-01-09",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 8.9
+    },
+    "weight": 97,
+    "network": {
+        "id": 9,
+        "name": "Showtime",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 25117,
+        "thetvdb": 161511,
+        "imdb": "tt1586680"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/45/114890.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/45/114890.jpg"
+    },
+    "summary": "<p><strong>Shameless</strong> is a fiercely engaging and fearlessly twisted series. Chicagoan Frank Gallagher is the proud single dad of six smart, industrious, independent kids, who without him would be... perhaps better off. When Frank's not at the bar spending what little money they have, he's passed out on the floor. But the kids have found ways to grow up in spite of him. They may not be like any family you know, but they make no apologies for being exactly who they are.</p>",
+    "updated": 1493478922,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/150"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/928422"
+        }
+    }
+}, {
+    "id": 151,
+    "url": "http://www.tvmaze.com/shows/151/the-newsroom",
+    "name": "The Newsroom",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2012-06-24",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 8.9
+    },
+    "weight": 0,
+    "network": {
+        "id": 8,
+        "name": "HBO",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 31286,
+        "thetvdb": 256227,
+        "imdb": "tt1870479"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/2066.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/2066.jpg"
+    },
+    "summary": "<p><strong>The Newsroom</strong> follows the members of a cable news team on their quixotic mission to do the news well in the face of a fickle audience, corporate mandates and tangled personal relationships.</p>",
+    "updated": 1483727481,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/151"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/11189"
+        }
+    }
+}, {
+    "id": 152,
+    "url": "http://www.tvmaze.com/shows/152/ray-donovan",
+    "name": "Ray Donovan",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Crime"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2013-06-30",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 8.5
+    },
+    "weight": 96,
+    "network": {
+        "id": 9,
+        "name": "Showtime",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 30309,
+        "thetvdb": 259866,
+        "imdb": "tt2249007"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/61/153390.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/61/153390.jpg"
+    },
+    "summary": "<p>Set in the sprawling mecca of the rich and famous, <strong>Ray Donovan</strong> does the dirty work for LA's top power players as the go-to guy who makes the problems of the city's celebrities, superstar athletes, and business moguls disappear. This powerful drama unfolds when his father is unexpectedly released from prison, setting off a chain of events that shakes the Donovan family to its core.</p>",
+    "updated": 1493461640,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/152"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/882419"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1157233"
+        }
+    }
+}, {
+    "id": 153,
+    "url": "http://www.tvmaze.com/shows/153/utopia",
+    "name": "Utopia",
+    "type": "Reality",
+    "language": "English",
+    "genres": [],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2014-09-07",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": null
+    },
+    "weight": 0,
+    "network": {
+        "id": 4,
+        "name": "FOX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 39954,
+        "thetvdb": 282654,
+        "imdb": "tt3703500"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/2090.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/2090.jpg"
+    },
+    "summary": "<p>Get ready to witness the birth of a brave new world. On the daring unscripted series <strong>Utopia</strong>, 15 pioneering Americans wave goodbye - for an entire year - to the lives they've known, move to a remote location and set out to create a society from scratch. They've got limited supplies, wildly diverse backgrounds and zero bathrooms.</p>",
+    "updated": 1490313454,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/153"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/15845"
+        }
+    }
+}, {
+    "id": 154,
+    "url": "http://www.tvmaze.com/shows/154/sanctuary",
+    "name": "Sanctuary",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Adventure", "Horror", "Science-Fiction"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2008-10-03",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 7.8
+    },
+    "weight": 95,
+    "network": {
+        "id": 16,
+        "name": "Syfy",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 18682,
+        "thetvdb": 80159,
+        "imdb": "tt0965394"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/2119.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/2119.jpg"
+    },
+    "summary": "<p><strong>Sanctuary</strong> follows the adventures of the beautiful, enigmatic and always surprising Dr. Helen Magnus, a brilliant scientist who holds the secrets of a clandestine population and a group of strange and sometimes terrifying beings that hide among humans.</p><p>Along with her new recruit, forensic psychiatrist Dr. Will Zimmerman, her quirky tech wiz Henry and her fearless daughter Ashley, Magnus seeks to protect this threatened phenomena as well as unlock the mysteries behind their existence.</p>",
+    "updated": 1493486670,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/154"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/11288"
+        }
+    }
+}, {
+    "id": 155,
+    "url": "http://www.tvmaze.com/shows/155/beauty-and-the-beast",
+    "name": "Beauty and the Beast",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Horror", "Romance"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2012-10-11",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Thursday"]
+    },
+    "rating": {
+        "average": 7.1
+    },
+    "weight": 1,
+    "network": {
+        "id": 5,
+        "name": "The CW",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 30717,
+        "thetvdb": 258959,
+        "imdb": "tt2193041"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/2128.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/2128.jpg"
+    },
+    "summary": "<p>Detective Catherine Chandler is a smart, no-nonsense homicide detective. When she was a teenager, she witnessed the murder of her mother at the hands of two gunmen and herself was saved by someone – or something. Years have passed and while investigating a murder, Catherine discovers a clue that leads her to Vincent Keller, who was reportedly killed in 2002. Catherine learns that Vincent is actually still alive and that it was he who saved her many years before. For mysterious reasons that have forced him to live outside of traditional society, Vincent has been in hiding for the past 10 years to guard his secret – when he is enraged, he becomes a terrifying beast, unable to control his super-strength and heightened senses.</p>",
+    "updated": 1491222946,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/155"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/905489"
+        }
+    }
+}, {
+    "id": 156,
+    "url": "http://www.tvmaze.com/shows/156/twin-peaks",
+    "name": "Twin Peaks",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Crime", "Supernatural"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "1990-04-08",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 8.4
+    },
+    "weight": 99,
+    "network": {
+        "id": 9,
+        "name": "Showtime",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 6450,
+        "thetvdb": 70533,
+        "imdb": "tt0098936"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/99/249543.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/99/249543.jpg"
+    },
+    "summary": "<p>Set in the fictional town of <strong>Twin Peaks</strong> in northeast Washington state, this is the story of FBI Special Agent Dale Cooper and his investigation of the murder of a popular local teenage schoolgirl, Laura Palmer.</p>",
+    "updated": 1494678444,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/156"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/11365"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1033061"
+        }
+    }
+}, {
+    "id": 157,
+    "url": "http://www.tvmaze.com/shows/157/the-americans",
+    "name": "The Americans",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Espionage"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2013-01-30",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 8.3
+    },
+    "weight": 99,
+    "network": {
+        "id": 13,
+        "name": "FX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 30449,
+        "thetvdb": 261690,
+        "imdb": "tt2149175"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/100/251858.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/100/251858.jpg"
+    },
+    "summary": "<p><strong>The Americans</strong> is a period drama about the complex marriage of two KGB spies posing as Americans in suburban Washington D.C. shortly after Ronald Reagan is elected President.</p>",
+    "updated": 1494448847,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/157"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1039851"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1039852"
+        }
+    }
+}, {
+    "id": 158,
+    "url": "http://www.tvmaze.com/shows/158/fringe",
+    "name": "Fringe",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Science-Fiction"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2008-09-09",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 8.9
+    },
+    "weight": 0,
+    "network": {
+        "id": 4,
+        "name": "FOX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 18388,
+        "thetvdb": 82066,
+        "imdb": "tt1119644"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/2245.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/2245.jpg"
+    },
+    "summary": "<p>\n\nWhen an international flight lands at Boston's Logan Airport\nand the passengers and crew have all died grisly deaths, FBI Special Agent Olivia\nDunham is called in to investigate. After her partner is nearly killed during\nthe investigation, a desperate Olivia searches frantically for someone to help,\nleading her to Dr. Walter Bishop, our generation's Einstein. There's only one catch:\nhe's been institutionalized for the last twenty years, and the only way to\nquestion him requires pulling his estranged son Peter in to help. When Olivia's\ninvestigation leads her to a manipulative corporate executive, she and her team\nwill discover that what happened on Flight 627 is only a small piece of a\nlarger, more shocking truth and will explore the blurring line between the possible and the impossible.</p>",
+    "updated": 1481566653,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/158"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/11492"
+        }
+    }
+}, {
+    "id": 159,
+    "url": "http://www.tvmaze.com/shows/159/state-of-affairs",
+    "name": "State of Affairs",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2014-11-17",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 6.3
+    },
+    "weight": 0,
+    "network": {
+        "id": 1,
+        "name": "NBC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 40241,
+        "thetvdb": 281519,
+        "imdb": "tt3489236"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/2215.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/2215.jpg"
+    },
+    "summary": "<p>Each day the President is faced with dozens of life and death decisions, and to prioritize the biggest international crises facing the country, one top CIA analyst — Charleston Tucker — assembles the President's Daily Briefing (PDB). This list of the most vital security issues facing the nation brings with it moral and political judgment calls for Charleston and... her trusted group of brilliant analysts at the agency. Aside from the political minefields she has to walk, Charlie has a close personal relationship with the President because she was once engaged to her son before a tragic terrorist attack took his life. Charlie survived that attack and is now determined to bring the perpetrators to justice. Navigating a complex personal life and a pressure-cooker profession is, of course, a challenge, and Charlie sometimes engages in boundary-pushing behavior to avoid facing her grief. But when the clock strikes 2 a.m., she is all about her job — protecting her nation, serving her President and still trying to get to the bottom of her fiancé's murder that will reveal itself as a shocking mystery.</p>",
+    "updated": 1459708916,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/159"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/128814"
+        }
+    }
+}, {
+    "id": 160,
+    "url": "http://www.tvmaze.com/shows/160/weeds",
+    "name": "Weeds",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Comedy", "Crime"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2005-08-07",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 8.4
+    },
+    "weight": 72,
+    "network": {
+        "id": 9,
+        "name": "Showtime",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 6554,
+        "thetvdb": 74845,
+        "imdb": "tt0439100"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/2216.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/2216.jpg"
+    },
+    "summary": "<p><strong>Weeds</strong> is a comedy/drama/satire based around an american widow (Nancy Botwin) with 2 children who begins selling cannabis for financial gain after the death of her husband. Her family become involved in more and more illegal activities as the show progresses.</p>",
+    "updated": 1493535553,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/160"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/11595"
+        }
+    }
+}, {
+    "id": 161,
+    "url": "http://www.tvmaze.com/shows/161/dexter",
+    "name": "Dexter",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Horror", "Thriller"],
+    "status": "Ended",
+    "runtime": 50,
+    "premiered": "2006-10-01",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 8.5
+    },
+    "weight": 89,
+    "network": {
+        "id": 9,
+        "name": "Showtime",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 7926,
+        "thetvdb": 79349,
+        "imdb": "tt0773262"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/39/99906.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/39/99906.jpg"
+    },
+    "summary": "<p><strong>Dexter</strong> is a crime drama series based around the main character, a serial killer named Dexter Morgan. Dexter only kills other killers and criminals and works in blood splatter analysis at crime scenes.</p>",
+    "updated": 1493506027,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/161"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/11691"
+        }
+    }
+}, {
+    "id": 162,
+    "url": "http://www.tvmaze.com/shows/162/carnivale",
+    "name": "Carnivàle",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Fantasy", "Horror"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2003-09-14",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 8.7
+    },
+    "weight": 75,
+    "network": {
+        "id": 8,
+        "name": "HBO",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 2990,
+        "thetvdb": 70860,
+        "imdb": "tt0319969"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/2256.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/2256.jpg"
+    },
+    "summary": "<p><strong>Carnivàle</strong> is set in the United States during the Great Depression and Dust Bowl. In tracing the lives of two disparate groups of people, its overarching story depicts the battle between good and evil and the struggle between free will and destiny, the storyline mixes Christian theology with Gnosticism and Masonic lore, particularly that of the Knights Templar.</p>",
+    "updated": 1492651584,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/162"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/11715"
+        }
+    }
+}, {
+    "id": 163,
+    "url": "http://www.tvmaze.com/shows/163/human-target",
+    "name": "Human Target",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Action", "Adventure", "Crime"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2010-01-17",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Wednesday"]
+    },
+    "rating": {
+        "average": 8.2
+    },
+    "weight": 66,
+    "network": {
+        "id": 4,
+        "name": "FOX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 22699,
+        "thetvdb": 94801,
+        "imdb": "tt1439741"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/42/106702.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/42/106702.jpg"
+    },
+    "summary": "<p>Christopher Chance is a unique private contractor/security expert/bodyguard hired when an unusual or imminent threat cannot be solved through normal means of protection. Chance works with his business partner and trusted friend, Winston, and hired gun, Guerrero, to integrate himself completely into his clients' lives and eliminate the threat by becoming the <strong>Human Target</strong>.</p>",
+    "updated": 1494690230,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/163"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/11740"
+        }
+    }
+}, {
+    "id": 164,
+    "url": "http://www.tvmaze.com/shows/164/banshee",
+    "name": "Banshee",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Crime"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2013-01-11",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 9.1
+    },
+    "weight": 0,
+    "network": {
+        "id": 19,
+        "name": "Cinemax",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 30823,
+        "thetvdb": 259765,
+        "imdb": "tt2017109"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/80/201761.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/80/201761.jpg"
+    },
+    "summary": "<p><strong>Banshee</strong> stars Antony Starr as Lucas Hood, an ex-con and master thief who assumes the identity of the sheriff of Banshee, Pennsylvania, where he continues his criminal activities, even as he's hunted by the shadowy gangsters he betrayed years earlier.</p>",
+    "updated": 1489221854,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/164"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/355639"
+        }
+    }
+}, {
+    "id": 165,
+    "url": "http://www.tvmaze.com/shows/165/bionic-woman",
+    "name": "Bionic Woman",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Action", "Science-Fiction"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2007-09-26",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Wednesday"]
+    },
+    "rating": {
+        "average": 6.4
+    },
+    "weight": 0,
+    "network": {
+        "id": 1,
+        "name": "NBC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 15187,
+        "thetvdb": 80370,
+        "imdb": "tt0880557"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/2303.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/2303.jpg"
+    },
+    "summary": "<p>When a devastating car accident leaves Jaime Sommer at death's door, her only hope of survival is a cutting-edge, top-secret technology performed by her boyfriend, Dr. Will Anthros and with her new bionics come a covert life that she is not sure she is ready to lead.</p>",
+    "updated": 1482053300,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/165"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/11804"
+        }
+    }
+}, {
+    "id": 166,
+    "url": "http://www.tvmaze.com/shows/166/battlestar-galactica",
+    "name": "Battlestar Galactica",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Adventure", "Science-Fiction", "War"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2005-01-14",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 9
+    },
+    "weight": 2,
+    "network": {
+        "id": 16,
+        "name": "Syfy",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 2730,
+        "thetvdb": 73545,
+        "imdb": "tt0407362"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/2313.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/2313.jpg"
+    },
+    "summary": "<p>The world ended with no warning, and all that was left… was hope.</p><p>A truce between the humans of the Twelve Colonies and the Cylons—intelligent robots designed by humankind—lasts for 40 tense and silent years. <strong>Battlestar Galactica</strong> picks up just as the Cylons commit mass genocide against humanity. Only the Battlestar Galactica (an old warship about to be decommissioned and turned into a museum) and those souls fortunate enough to be aboard other starships were able to survive the attack. In the aftermath, the Galactica's commanding officer, William Adama, finds himself responsible for safeguarding the last remnants of the human race—fewer than 50,000 desperate survivors. Meanwhile, the annihilation of the Colonial government results in the succession of the Secretary of Education, Laura Roslin, to the presidency. Driven by prophetic visions and political necessity, the Galactica travels through uncharted space in hopes of finding the mythical, lost 13th colony—Earth.</p>",
+    "updated": 1491142699,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/166"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/11879"
+        }
+    }
+}, {
+    "id": 167,
+    "url": "http://www.tvmaze.com/shows/167/24",
+    "name": "24",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Thriller"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2001-11-06",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 8.5
+    },
+    "weight": 93,
+    "network": {
+        "id": 4,
+        "name": "FOX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 2445,
+        "thetvdb": 76290,
+        "imdb": "tt0285331"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/2330.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/2330.jpg"
+    },
+    "summary": "<p>Jack Bauer, agent of CTU (Counter Terrorist Unit) faces threats against his country and himself in this action packed show. Each season contains of one day, each episode shows one hour of Jack Bauer's day. <strong>24</strong> is the only action show in real time and gained a lot of fans during the years with this concept.</p>",
+    "updated": 1492629586,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/167"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/12094"
+        }
+    }
+}, {
+    "id": 168,
+    "url": "http://www.tvmaze.com/shows/168/chuck",
+    "name": "Chuck",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Comedy", "Action", "Science-Fiction"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2007-09-24",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 8.8
+    },
+    "weight": 86,
+    "network": {
+        "id": 1,
+        "name": "NBC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 15614,
+        "thetvdb": 80348,
+        "imdb": "tt0934814"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/2385.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/2385.jpg"
+    },
+    "summary": "<p><strong>Chuck</strong> Bartowski is a computer geek that gets catapulted into a new career as the government's most vital secret agent. When Chuck opens an e-mail subliminally encoded with government secrets, he unwittingly downloads an entire server of sensitive data into his brain. With the government's most precious secrets in Chuck's head, Major John Casey of the National Security Agency assumes the responsibility of protecting him. His partner is the CIA's top agent, Sarah Walker.</p>",
+    "updated": 1494690946,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/168"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/12191"
+        }
+    }
+}, {
+    "id": 169,
+    "url": "http://www.tvmaze.com/shows/169/breaking-bad",
+    "name": "Breaking Bad",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Crime", "Thriller"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2008-01-20",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 9.3
+    },
+    "weight": 95,
+    "network": {
+        "id": 20,
+        "name": "AMC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 18164,
+        "thetvdb": 81189,
+        "imdb": "tt0903747"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/2400.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/2400.jpg"
+    },
+    "summary": "<p><strong>Breaking Bad</strong> follows protagonist Walter White, a chemistry teacher who lives in New Mexico with his wife and teenage son who has cerebral palsy. White is diagnosed with Stage III cancer and given a prognosis of two years left to live. With a new sense of fearlessness based on his medical prognosis, and a desire to secure his family's financial security, White chooses to enter a dangerous world of drugs and crime and ascends to power in this world. The series explores how a fatal diagnosis such as White's releases a typical man from the daily concerns and constraints of normal society and follows his transformation from mild family man to a kingpin of the drug trade.</p>",
+    "updated": 1492759964,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/169"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/12253"
+        }
+    }
+}, {
+    "id": 170,
+    "url": "http://www.tvmaze.com/shows/170/orange-is-the-new-black",
+    "name": "Orange is the New Black",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Comedy", "Crime"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2013-07-11",
+    "schedule": {
+        "time": "",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 8.1
+    },
+    "weight": 99,
+    "network": null,
+    "webChannel": {
+        "id": 1,
+        "name": "Netflix",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "externals": {
+        "tvrage": 32950,
+        "thetvdb": 264586,
+        "imdb": "tt2372162"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/58/147441.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/58/147441.jpg"
+    },
+    "summary": "<p><strong>Orange is the New Black</strong> is the story of\nPiper Chapman, a woman in her thirties who is sentenced to fifteen months in\nprison after being convicted of a decade-old crime of transporting money for\nher drug-dealing girlfriend.</p>",
+    "updated": 1494076220,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/170"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/665288"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1066679"
+        }
+    }
+}, {
+    "id": 171,
+    "url": "http://www.tvmaze.com/shows/171/how-i-met-your-mother",
+    "name": "How I Met Your Mother",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Comedy", "Romance"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2005-09-19",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 7.8
+    },
+    "weight": 1,
+    "network": {
+        "id": 2,
+        "name": "CBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 3918,
+        "thetvdb": 75760,
+        "imdb": "tt0460649"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/2451.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/2451.jpg"
+    },
+    "summary": "<p><strong>How I Met Your Mother</strong> is a comedy about Ted and how he fell in love. It all starts when Ted's best friend, Marshall drops the bombshell that he's going to propose to his long-time girlfriend, Lilya kindergarten teacher. At that moment, Ted realizes that he had better get a move on if he too hopes to find true love. Helping him in his quest is Barney a friend with endless, sometimes outrageous opinions, a penchant for suits and a foolproof way to meet women. When Ted meets Robin he's sure it's love at first sight, but destiny may have something else in store.</p>",
+    "updated": 1490696877,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/171"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/12492"
+        }
+    }
+}, {
+    "id": 172,
+    "url": "http://www.tvmaze.com/shows/172/suits",
+    "name": "Suits",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Legal"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2011-06-23",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Wednesday"]
+    },
+    "rating": {
+        "average": 8.5
+    },
+    "weight": 98,
+    "network": {
+        "id": 30,
+        "name": "USA Network",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 27518,
+        "thetvdb": 247808,
+        "imdb": "tt1632701"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/2432.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/2432.jpg"
+    },
+    "summary": "<p><strong>Suits</strong> delves into the fast-paced, high-stakes world of a top Manhattan corporate law firm where hotshot associate Harvey Specter makes a risky move by hiring Mike Ross a brilliant but unmotivated college dropout, as his associate. As he becomes enmeshed in this unfamiliar world, Mike relies heavily on the firm's best paralegal Rachel Zane and Harvey's no-nonsense assistant Donna Paulsen to help him serve justice. With a photographic memory and the street smarts of a hustler, Mike proves to be a legal prodigy despite the absence of bonafide legal credentials.</p>",
+    "updated": 1493727808,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/172"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1047341"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1160583"
+        }
+    }
+}, {
+    "id": 174,
+    "url": "http://www.tvmaze.com/shows/174/parks-and-recreation",
+    "name": "Parks and Recreation",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2009-04-09",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Thursday"]
+    },
+    "rating": {
+        "average": 8.7
+    },
+    "weight": 86,
+    "network": {
+        "id": 1,
+        "name": "NBC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 21686,
+        "thetvdb": 84912,
+        "imdb": "tt1266020"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/0/2439.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/0/2439.jpg"
+    },
+    "summary": "<p><strong>Parks and Recreation</strong> is a comedy series based around the main character Leslie Knope (a bureaucrat) in the parks department of Pawnee.</p>",
+    "updated": 1494631754,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/174"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/57787"
+        }
+    }
+}, {
+    "id": 175,
+    "url": "http://www.tvmaze.com/shows/175/house-of-cards",
+    "name": "House of Cards",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Thriller"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2013-02-01",
+    "schedule": {
+        "time": "",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 8.7
+    },
+    "weight": 98,
+    "network": null,
+    "webChannel": {
+        "id": 1,
+        "name": "Netflix",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "externals": {
+        "tvrage": 27822,
+        "thetvdb": 262980,
+        "imdb": "tt1856010"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/78/196742.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/78/196742.jpg"
+    },
+    "summary": "<p>A Congressman works with his equally conniving wife to exact revenge on the people who betrayed him.</p>",
+    "updated": 1493711998,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/175"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/535325"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1001769"
+        }
+    }
+}, {
+    "id": 176,
+    "url": "http://www.tvmaze.com/shows/176/teen-wolf",
+    "name": "Teen Wolf",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Romance", "Supernatural"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2011-06-05",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 7.9
+    },
+    "weight": 98,
+    "network": {
+        "id": 22,
+        "name": "MTV",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 27575,
+        "thetvdb": 175001,
+        "imdb": "tt1567432"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/91/227940.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/91/227940.jpg"
+    },
+    "summary": "<p>Always an outsider and often unnoticed, Scott McCall yearns to be recognized in some small way that takes him out of his typical state of high school anonymity. When his best friend, Stiles, convinces him to go into the woods one night to join a police search for a dead body, Scott encounters a creature in the darkness. Narrowly escaping an attack with a vicious bite in his side, the next day brings strange surprises for Scott at school and his life will never be the same.</p><p>MTV's reboot of the classic 1980s cult movie <strong>Teen Wolf</strong>.</p>",
+    "updated": 1493476577,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/176"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1033918"
+        }
+    }
+}, {
+    "id": 177,
+    "url": "http://www.tvmaze.com/shows/177/pretty-little-liars",
+    "name": "Pretty Little Liars",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Romance", "Mystery"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2010-06-08",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 8.1
+    },
+    "weight": 99,
+    "network": {
+        "id": 26,
+        "name": "FreeForm",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 25591,
+        "thetvdb": 146711,
+        "imdb": "tt1578873"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/47/119740.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/47/119740.jpg"
+    },
+    "summary": "<p>Rosewood is a perfect little town. So quiet and pristine, you'd never guess it holds so many secrets. Some of the ugliest ones belong to the prettiest girls in town: Aria, Spencer, Hanna and Emily, four friends whose darkest secrets have been unraveling since Alison, the Queen Bee of their group disappeared. As the mystery surrounding Ali's disappearance resurfaces, the girls begin getting messages from a mysterious \"A,\" who they quickly realize is out to get them. Now, after years of tormenting and numerous shocking revelations, the Liars are united and ready to kick some \"A\" and uncover the truth! No longer just wanting to sit by and wait for \"A's\" latest cruel attack, Aria, Emily, Hanna and Spencer take matters into their own hands and try to finally put a stop to their tormentor. As relationships are put to the test, new and old secrets are revealed and the stakes are raised higher than ever before as the Liars come closer to the truth. Will all of their sacrifices be worth it in the end?</p>",
+    "updated": 1494678043,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/177"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/909996"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/909997"
+        }
+    }
+}, {
+    "id": 178,
+    "url": "http://www.tvmaze.com/shows/178/the-legend-of-korra",
+    "name": "The Legend of Korra",
+    "type": "Animation",
+    "language": "English",
+    "genres": ["Action", "Adventure", "Children", "Fantasy"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2012-04-14",
+    "schedule": {
+        "time": "12:00",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 8.9
+    },
+    "weight": 1,
+    "network": {
+        "id": 27,
+        "name": "Nickelodeon",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 26254,
+        "thetvdb": 251085,
+        "imdb": "tt1695360"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/42/106243.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/42/106243.jpg"
+    },
+    "summary": "<p>Avatar Korra fights to keep Republic City safe from the evil forces of both the physical and spiritual worlds.</p>",
+    "updated": 1490715803,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/178"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/58140"
+        }
+    }
+}, {
+    "id": 179,
+    "url": "http://www.tvmaze.com/shows/179/the-wire",
+    "name": "The Wire",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Crime", "Thriller"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2002-06-02",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 9.4
+    },
+    "weight": 68,
+    "network": {
+        "id": 8,
+        "name": "HBO",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 6296,
+        "thetvdb": 79126,
+        "imdb": "tt0306414"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/2527.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/2527.jpg"
+    },
+    "summary": "<p>The first season of <em>The Wire</em> (2002) concentrated on the often-futile efforts of police to infiltrate a West Baltimore drug ring headed by Avon Barksdale and his lieutenant, Stringer Bell. In Seasons Two and Three, as the Barksdale investigation escalated, new storylines involving pressures on the working class and the city's political leadership were introduced. Season Four focused on the stories of several young boys in the public school system, struggling with problems at home and the lure of the corner - set against the rise of a new drug empire in West Baltimore and a new Mayor in City Hall. The fifth and final season of <em>The Wire</em> centers on the media's role in addressing - or failing to address - the fundamental political, economic and social realities depicted over the course of the series, while also resolving storylines of the numerous characters woven throughout the narrative arc of the show.</p>",
+    "updated": 1492651554,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/179"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/12969"
+        }
+    }
+}, {
+    "id": 180,
+    "url": "http://www.tvmaze.com/shows/180/firefly",
+    "name": "Firefly",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Adventure", "Science-Fiction", "Western"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2002-09-20",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 9.3
+    },
+    "weight": 1,
+    "network": {
+        "id": 4,
+        "name": "FOX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 3548,
+        "thetvdb": 78874,
+        "imdb": "tt0303461"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/2600.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/2600.jpg"
+    },
+    "summary": "<p>Five hundred years in the future, a renegade crew aboard a small spacecraft tries to survive as they travel the unknown parts of the galaxy and evade warring factions as well as authority agents out to get them.</p>",
+    "updated": 1477835152,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/180"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/13006"
+        }
+    }
+}, {
+    "id": 181,
+    "url": "http://www.tvmaze.com/shows/181/extant",
+    "name": "Extant",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Science-Fiction", "Thriller"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2014-07-09",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Wednesday"]
+    },
+    "rating": {
+        "average": 7.5
+    },
+    "weight": 0,
+    "network": {
+        "id": 2,
+        "name": "CBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 37050,
+        "thetvdb": 272127,
+        "imdb": "tt3155320"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/54/136509.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/54/136509.jpg"
+    },
+    "summary": "<p>Molly Woods is an astronaut who returns home from a year-long solo mission in space and tries to reconnect with her husband and son in their everyday life. Her experiences in space and home lead to events that ultimately will change the course of human history.</p>",
+    "updated": 1490253586,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/181"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/201866"
+        }
+    }
+}, {
+    "id": 182,
+    "url": "http://www.tvmaze.com/shows/182/black-sails",
+    "name": "Black Sails",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Adventure"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2014-01-25",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 8.5
+    },
+    "weight": 98,
+    "network": {
+        "id": 17,
+        "name": "Starz",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 32725,
+        "thetvdb": 262407,
+        "imdb": "tt2375692"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/78/195951.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/78/195951.jpg"
+    },
+    "summary": "<p>1715. The Golden Age of Piracy. New Providence Island is a lawless territory, controlled by history's most notorious pirate captains. The most feared is Captain Flint. </p><p>As the British Navy returns to redeem their land and exterminate Flint and his crew, another side of him emerges. Captain Flint aligns himself with Eleanor Guthrie, daughter of the local kingpin, to hunt the ultimate prize and ensure their survival.</p><p>Many opponents stand in their way: rival captains, jealous of Flint's power; Eleanor's ambitious and intrusive father; and a young sailor recently recruited onto Flint's crew, John Silver, who constantly undermines his captain's agenda.</p>",
+    "updated": 1493474844,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/182"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1049151"
+        }
+    }
+}, {
+    "id": 183,
+    "url": "http://www.tvmaze.com/shows/183/tyrant",
+    "name": "Tyrant",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Thriller"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2014-06-24",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Wednesday"]
+    },
+    "rating": {
+        "average": 8.1
+    },
+    "weight": 1,
+    "network": {
+        "id": 13,
+        "name": "FX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 33816,
+        "thetvdb": 268094,
+        "imdb": "tt2568204"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/2649.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/2649.jpg"
+    },
+    "summary": "<p><strong>Tyrant</strong> is a drama that follows a typical American family whose members find themselves embroiled in the geopolitical intrigue of a volatile Middle Eastern country. Barry Al-Fayeed is a California pediatrician who also happens to be the second son of a Middle Eastern dictator. Barry reluctantly agrees to return home with his American family for his nephew's wedding. Events thrust him into the complex and turbulent growing pains of a nation straining to break free from dictatorial rule.</p>",
+    "updated": 1477706355,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/183"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/738572"
+        }
+    }
+}, {
+    "id": 184,
+    "url": "http://www.tvmaze.com/shows/184/bojack-horseman",
+    "name": "BoJack Horseman",
+    "type": "Animation",
+    "language": "English",
+    "genres": ["Drama", "Comedy"],
+    "status": "Running",
+    "runtime": 25,
+    "premiered": "2014-08-22",
+    "schedule": {
+        "time": "",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 8.3
+    },
+    "weight": 0,
+    "network": null,
+    "webChannel": {
+        "id": 1,
+        "name": "Netflix",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "externals": {
+        "tvrage": 39470,
+        "thetvdb": 282254,
+        "imdb": "tt3398228"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/59/149083.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/59/149083.jpg"
+    },
+    "summary": "<p>Meet the most beloved sitcom horse of the '90s, 20 years later. He's a curmudgeon with a heart of...not quite gold...but something like gold. Copper?</p>",
+    "updated": 1477510743,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/184"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/872197"
+        }
+    }
+}, {
+    "id": 185,
+    "url": "http://www.tvmaze.com/shows/185/salem",
+    "name": "Salem",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Thriller", "Supernatural"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2014-04-20",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Wednesday"]
+    },
+    "rating": {
+        "average": 7.5
+    },
+    "weight": 17,
+    "network": {
+        "id": 28,
+        "name": "WGN America",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 36241,
+        "thetvdb": 274897,
+        "imdb": "tt2963254"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/73/184895.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/73/184895.jpg"
+    },
+    "summary": "<p>Set in 17th century colonial Massachusetts—a significant time in the history of American politics, religion and society— <strong>Salem</strong> brings you the real story behind the infamous witch trials. In Salem, witches are real, and they're behind it all. Salem Village and Salem Town feuded over property, grazing rights and church rights. The government was dominated by Puritan leaders. People were scrutinized closely and this resulted in obvious discord. They were afraid of being persecuted for anything that may offend the Puritan mindset. The word \"witch\" seemed an easy and appropriate curse hurled at someone who behaved abnormally.</p>",
+    "updated": 1485702586,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/185"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1014881"
+        }
+    }
+}, {
+    "id": 186,
+    "url": "http://www.tvmaze.com/shows/186/turn-washington-spies",
+    "name": "Turn: Washington Spies",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "War"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2014-04-06",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 8.2
+    },
+    "weight": 94,
+    "network": {
+        "id": 20,
+        "name": "AMC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 33631,
+        "thetvdb": 272135,
+        "imdb": "tt2543328"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/57/143037.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/57/143037.jpg"
+    },
+    "summary": "<p><strong>Turn: Washington Spies</strong> takes viewers into the stirring and treacherous world of the Revolutionary War and introduces Abraham Woodhull who, after aligning with a group of childhood friends, forms the Culper Ring--America's first spy ring.</p>",
+    "updated": 1493230735,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/186"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/781295"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1155704"
+        }
+    }
+}, {
+    "id": 187,
+    "url": "http://www.tvmaze.com/shows/187/intelligence",
+    "name": "Intelligence",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Action", "Science-Fiction"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2014-01-07",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 6.5
+    },
+    "weight": 1,
+    "network": {
+        "id": 2,
+        "name": "CBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 34469,
+        "thetvdb": 267260,
+        "imdb": "tt2693776"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/2715.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/2715.jpg"
+    },
+    "summary": "<p><strong>Intelligence</strong> is a dramatic thriller about a high-tech intelligence operative enhanced with a super-computer microchip in his brain. With this implant, Gabriel Vaughn is the first human ever to be connected directly into the worldwide information grid and have complete access to Internet, WiFi, telephone and satellite data. He can hack into any data center and access key Intel in the fight to protect the United States from its enemies. Leading the elite government cyber-security agency created to support him is Director Lillian Strand, a straightforward and efficient boss who oversees the unit's missions. Strand assigns Riley Neal, a Secret Service agent, to protect Gabriel from outside threats, as well as from his appetite for reckless, unpredictable behavior and disregard for protocol. Other skilled members of the Cybercom team include Chris Jameson and Gonzalo \"Gonzo\" Rodriguez two resourceful federal investigators. The brains behind the design of the chip is Dr. Shenendoah Cassidy, whose son, Nelson is jealous of Gabriel's prominent place in his father's life. As the first supercomputer with a beating heart, Gabriel is the most valuable piece of technology the country has ever created and is the U.S.'s secret weapon.</p>",
+    "updated": 1484535037,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/187"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/13093"
+        }
+    }
+}, {
+    "id": 188,
+    "url": "http://www.tvmaze.com/shows/188/believe",
+    "name": "Believe",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Family", "Fantasy"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2014-03-10",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 7.5
+    },
+    "weight": 0,
+    "network": {
+        "id": 1,
+        "name": "NBC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 34327,
+        "thetvdb": 267258,
+        "imdb": "tt2592094"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/51/127824.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/51/127824.jpg"
+    },
+    "summary": "<p>Levitation, telekinesis, the ability to control nature and even predict the future... Since she was 2 years old, Bo has had gifts she could neither fully understand, nor control. Raised by a small group known as the \"True Believers,\" the orphaned girl has been safeguarded from harmful outsiders who would use her forces for personal gain. But now that she is 10, her powers have become stronger and the threat has grown more dangerous. With her life and future now in jeopardy, the \"Believers\" turn to the only person they see fit to be her full-time protector. That is, once they break him out of jail. Tate, a wrongfully imprisoned death row inmate who's lost his will, is initially reluctant until he witnesses one of her extraordinary abilities. Bo sees people for who they truly are... and who they may become. Tate and Bo begin their journey, one in which trust must be earned. Traveling from city to city, every place they stop and everyone they meet will be changed forever. But they'll have to keep going to stay one step ahead of the sinister forces after Bo's power... because it will take a miracle to keep them safe forever.</p>",
+    "updated": 1480224265,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/188"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/13111"
+        }
+    }
+}, {
+    "id": 189,
+    "url": "http://www.tvmaze.com/shows/189/star-crossed",
+    "name": "Star-Crossed",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Romance", "Science-Fiction"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2014-02-17",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 7
+    },
+    "weight": 77,
+    "network": {
+        "id": 5,
+        "name": "The CW",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 34563,
+        "thetvdb": 269604,
+        "imdb": "tt2657262"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/2776.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/2776.jpg"
+    },
+    "summary": "<p>When Emery was 6 years old, an alien spacecraft crash-landed in her small town. Whether they came in peace or with more sinister intentions didn't matter: a fierce battle erupted as humans fought for control over their new rivals, an alien species called the Atrians. In the midst of the conflict, Roman, a 6-year-old Atrian boy, found his way to a shed behind Emery's house, where she protected him from harm, bringing him food, comfort - and friendship. In their brief time together, Emery and Roman forged a deep bond, but the authorities wasted no time tracking Roman down and capturing him in a violent confrontation. Emery has grown up believing that Roman was killed that day. Ten years later, the Atrians have been acclimated to life on Earth, but they are interned in a heavily-guarded camp known as the Sector to keep them separate from humans. Now, for the first time, a group of Atrian teens will enroll in a suburban human high school, with the goal of testing the feasibility of human/alien integration. The eyes of the nation and the whole world are fixed on this historical social experiment, an endeavor fraught with suspicion and fear. In the mayhem of the first day, Emery is amazed to learn that Roman was not killed by the authorities and is, in fact, one of the Atrian students. Their childhood bond is quickly rekindled - in a school and a society that distrusts everything about the Atrians, Emery and Roman have found each other again. However, their relationship is threatened by the small-mindedness of their respective communities and the political agendas of people in power. While the world around them rages with anger and prejudice, their bond becomes increasingly strong and increasingly dangerous. As an epic Romeo and Juliet romance unfolds, a violent encounter between Roman's father and Emery's father occurs in the Sector. Can Roman and Emery's love - and peace between the species - survive?</p>",
+    "updated": 1493864166,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/189"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/13125"
+        }
+    }
+}, {
+    "id": 190,
+    "url": "http://www.tvmaze.com/shows/190/crisis",
+    "name": "Crisis",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Action", "Thriller"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2014-03-16",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 7.5
+    },
+    "weight": 0,
+    "network": {
+        "id": 1,
+        "name": "NBC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 35791,
+        "thetvdb": 269592,
+        "imdb": "tt2322158"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/2786.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/2786.jpg"
+    },
+    "summary": "<p>It's field trip day for the students of Ballard High School, a place that educates the children of Washington, D.C.'s elite, top-of-their-industry CEOs, international diplomats, political power players and even the president's son. But when their bus is ambushed on a secluded rural road, the teenagers and their chaperones are taken, igniting a national crisis. Now with some of the country's most powerful parents at the mercy of one vengeful mastermind, the question arises: How far would you go and what would you become to ensure your child's safe return? With so many parents and dignitaries put into play with nowhere to turn and no one to trust, this unthinkable scenario grows from the select families at risk to an entire nation at stake.</p>",
+    "updated": 1476293778,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/190"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/13138"
+        }
+    }
+}, {
+    "id": 191,
+    "url": "http://www.tvmaze.com/shows/191/halt-and-catch-fire",
+    "name": "Halt and Catch Fire",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2014-06-01",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 8.1
+    },
+    "weight": 96,
+    "network": {
+        "id": 20,
+        "name": "AMC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": {
+        "id": 1,
+        "name": "Netflix",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "externals": {
+        "tvrage": 33630,
+        "thetvdb": 271910,
+        "imdb": "tt2543312"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/54/137497.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/54/137497.jpg"
+    },
+    "summary": "<p><strong>Halt and Catch Fire</strong> is set roughly one year after IBM all but corners the market with the release of its first major product – the IBM PC. In this fictional drama, a former IBM executive, Joe MacMillan plans to reverse engineer the flagship product of his former employer and forces his current company, Cardiff Electric, into the personal computer race. MacMillan enlists the help of Gordon Clark, a great engineer whose unrealized dreams of creating a revolutionary product have created tension in his marriage to Donna, and Cameron Howe, a volatile prodigy who puts her future in jeopardy to join MacMillan's rogue PC project. Halt and Catch Fire thrives on the spirit of innovation and explores what it's like to stand at the forefront of something world-changing and work towards it, no matter the risk.</p>",
+    "updated": 1493483399,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/191"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/768042"
+        }
+    }
+}, {
+    "id": 192,
+    "url": "http://www.tvmaze.com/shows/192/hello-ladies",
+    "name": "Hello Ladies",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2013-09-29",
+    "schedule": {
+        "time": "22:30",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 6.3
+    },
+    "weight": 0,
+    "network": {
+        "id": 8,
+        "name": "HBO",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 32368,
+        "thetvdb": 265609,
+        "imdb": "tt2378794"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/2826.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/2826.jpg"
+    },
+    "summary": "<p>Stewart is a gawky, 6' 7\" Englishman searching for the woman of his dreams in Los Angeles. Half as charming - and twice as desperate - as he thinks he is, he's obsessed with infiltrating the glamorous world of beautiful people, who won't let him in.</p>",
+    "updated": 1481775330,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/192"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/13159"
+        }
+    }
+}, {
+    "id": 193,
+    "url": "http://www.tvmaze.com/shows/193/dads",
+    "name": "Dads",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2013-09-17",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 5.4
+    },
+    "weight": 0,
+    "network": {
+        "id": 4,
+        "name": "FOX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 34573,
+        "thetvdb": 269589,
+        "imdb": "tt2647548"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/2831.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/2831.jpg"
+    },
+    "summary": "<p>Honor thy father. Way easier said than done. Especially when your dad's broke, living in your house and ruining your life. <strong>Dads</strong> explores the often treacherous terrain of the father-son landscape. This series follows two successful guys - and childhood best friends - now in their mid-30s whose relatively stable lives get turned upside down when their pain-in-the-neck patriarchs move in.</p>",
+    "updated": 1485102230,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/193"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/13177"
+        }
+    }
+}, {
+    "id": 194,
+    "url": "http://www.tvmaze.com/shows/194/hannibal",
+    "name": "Hannibal",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Crime", "Horror", "Thriller"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2013-04-04",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Thursday"]
+    },
+    "rating": {
+        "average": 8.5
+    },
+    "weight": 87,
+    "network": {
+        "id": 1,
+        "name": "NBC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 30909,
+        "thetvdb": 259063,
+        "imdb": "tt2243973"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/2839.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/2839.jpg"
+    },
+    "summary": "<p>Criminal profiler Will Graham is tasked by FBI agent Jack Crawford, the head of Behavioral Sciences, to help investigate the disappearances of eight young girls across Minnesota. Graham and Crawford's team investigate several subsequent murders, while also trying to catch the Chesapeake Ripper. With the investigation weighing heavily on Graham, Crawford decides to have him supervised by psychiatrist Dr. Hannibal Lecter, who, unbeknownst to them, is the Chesapeake Ripper himself, actively seeking to derail the investigation.</p>",
+    "updated": 1494685567,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/194"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/201570"
+        }
+    }
+}, {
+    "id": 195,
+    "url": "http://www.tvmaze.com/shows/195/bates-motel",
+    "name": "Bates Motel",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Horror", "Thriller", "Mystery"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2013-03-18",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 8.1
+    },
+    "weight": 100,
+    "network": {
+        "id": 29,
+        "name": "A&E",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 32210,
+        "thetvdb": 262414,
+        "imdb": "tt2188671"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/2855.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/2855.jpg"
+    },
+    "summary": "<p><strong>Bates Motel</strong> is a contemporary prequel to the genre-defining film Psycho, and gives viewers an intimate portrayal of how Norman Bates' psyche unravels through his teenage years.</p><p>Following the tragic death of her husband, Norma Bates buys a motel on the outskirts of the idyllic coastal town of White Pine Bay, seeking a fresh start. As Norma and Norman get ensconced in their new home, they discover this town isn't quite what it seems, and the locals aren't so quick to let them in on their secrets. But the Bates' are done being pushed around and will do whatever it takes to survive - and will do whatever it takes to protect their own secrets.</p>",
+    "updated": 1493398308,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/195"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1048216"
+        }
+    }
+}, {
+    "id": 196,
+    "url": "http://www.tvmaze.com/shows/196/the-following",
+    "name": "The Following",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Crime", "Horror", "Thriller", "Mystery"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2013-01-21",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 7.3
+    },
+    "weight": 0,
+    "network": {
+        "id": 4,
+        "name": "FOX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 31672,
+        "thetvdb": 258744,
+        "imdb": "tt2071645"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/2868.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/2868.jpg"
+    },
+    "summary": "<p>Season One found Ryan dragged back into a world of horror, when the FBI reached out to him in the wake of Joe's escape from death row. Challenged with an ever-growing web of murders, Ryan and the FBI soon discovered they were up against not one killer, but a cult of killers directed by Joe, who appeared to die in a fiery explosion at season's end. </p><p>As Season Two unfolded, Ryan, FBI Agent Mike Weston and Ryan's niece, NYPD officer Max Hardly led an off-the-books investigation into Joe's presumed death and the whereabouts of his cult's remaining members.</p>",
+    "updated": 1469747864,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/196"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/155296"
+        }
+    }
+}, {
+    "id": 197,
+    "url": "http://www.tvmaze.com/shows/197/da-vincis-demons",
+    "name": "Da Vinci's Demons",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Horror"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2013-04-12",
+    "schedule": {
+        "time": "",
+        "days": ["Saturday"]
+    },
+    "rating": {
+        "average": 8.1
+    },
+    "weight": 86,
+    "network": null,
+    "webChannel": {
+        "id": 46,
+        "name": "Starz Play",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "externals": {
+        "tvrage": 32724,
+        "thetvdb": 259669,
+        "imdb": "tt2094262"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/2892.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/2892.jpg"
+    },
+    "summary": "<p>In a world where thought and faith are controlled, one man fights to set knowledge free. Leonardo da Vinci is tortured by a gift of superhuman genius. He finds himself in a conflict between truth and lies, religion and reason, past and future. His aspirations are used against him by opposing forces – luring him into a game of seduction where those who despise his intellect need him most. </p><p>His quest for knowledge nearly becomes his undoing, but da Vinci's genius prevails and he emerges as an unstoppable force that lifts an entire era out of darkness and propels it into light. His story becomes a mirror into our own world, calling us all to join his fight to free the future.</p>",
+    "updated": 1494071953,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/197"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/371864"
+        }
+    }
+}, {
+    "id": 198,
+    "url": "http://www.tvmaze.com/shows/198/the-fosters",
+    "name": "The Fosters",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Family", "Romance"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2013-06-03",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 8.2
+    },
+    "weight": 94,
+    "network": {
+        "id": 26,
+        "name": "FreeForm",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 33919,
+        "thetvdb": 267907,
+        "imdb": "tt2262532"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/63/158843.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/63/158843.jpg"
+    },
+    "summary": "<p> <strong>The Fosters</strong> is a critically-acclaimed series that centers on biracial lesbian couple Stef and Lena Foster, who are raising a multi-ethnic family mix of foster and biological kids. The second season will continue to explore the growing Fosters clan, with all the triumphs and travails, twists and turns, that fans of the series have come to expect. Callie and Jude will try to adjust to their new roles in the family, and everyone will deal with the fallout from their previous actions. Past mistakes will come home to roost, consequences will be handed out, and victories will be hard fought, and ultimately well-won. Their deep bonds will grow, enabling America's most modern family to face the future head on, with love in their hearts.</p>",
+    "updated": 1493507970,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/198"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1075114"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1139607"
+        }
+    }
+}, {
+    "id": 199,
+    "url": "http://www.tvmaze.com/shows/199/mistresses",
+    "name": "Mistresses",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Romance"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2013-06-03",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Thursday"]
+    },
+    "rating": {
+        "average": 7.3
+    },
+    "weight": 0,
+    "network": {
+        "id": 3,
+        "name": "ABC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 30882,
+        "thetvdb": 259054,
+        "imdb": "tt2295809"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/2950.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/2950.jpg"
+    },
+    "summary": "<p>Based on the hit UK television series of the same name, <strong>Mistresses</strong> is a provocative and thrilling drama about the scandalous lives of a sexy and sassy group of four girlfriends, each on her own path to self-discovery. These four friends find support and guidance with each other as they brave their turbulent journeys and life's storms of excitement, secrecy and betrayal, all the while bound by the complex relationships they've created. </p>",
+    "updated": 1490068706,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/199"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/900600"
+        }
+    }
+}, {
+    "id": 200,
+    "url": "http://www.tvmaze.com/shows/200/the-tomorrow-people",
+    "name": "The Tomorrow People",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Action", "Science-Fiction"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2013-10-09",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 7.3
+    },
+    "weight": 54,
+    "network": {
+        "id": 5,
+        "name": "The CW",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 34626,
+        "thetvdb": 268591,
+        "imdb": "tt2660734"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/55/138044.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/55/138044.jpg"
+    },
+    "summary": "<p>They are the next evolutionary leap of mankind, a generation of humans born with paranormal abilities - <strong>The Tomorrow People</strong>. Stephen Jameson stands at the crossroads between the world we know and the shifting world of the future. Up until a year ago, Stephen was a \"normal\" teenager - until he began hearing voices and teleporting in his sleep, never knowing where he might wake up. Now, Stephen's issues have gone far beyond the usual teenage angst, and he is beginning to question his sanity. In desperation, Stephen decides to listen to one of the voices in his head, and it leads him to his first encounter with the Tomorrow People - John, Cara and Russell - a genetically advanced race with the abilities of telekinesis, teleportation and telepathic communication. The Tomorrow People are being hunted down by a paramilitary group of scientists known as Ultra. Led by Dr. Jedikiah Price, Ultra sees the Tomorrow People as a very real existential threat from a rival species, and the outcast group has been forced to hide out in an abandoned subway station just beneath the surface of the human world. Trading in secrets, Jedikiah offers Stephen the chance for a normal life with his family and best friend, Astrid, if he will help in the struggle to isolate and eradicate the Tomorrow People. On the other hand, Cara, John and Russell offer Stephen a different type of family and a home where he truly belongs. Unwilling to turn his back on humanity or the world of the Tomorrow People, Stephen sets out on his own path - a journey that could take him into the shadowy past to uncover the truth about his father's mysterious disappearance, or into an unknown future with The Tomorrow People.</p>",
+    "updated": 1494604237,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/200"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/13358"
+        }
+    }
+}, {
+    "id": 201,
+    "url": "http://www.tvmaze.com/shows/201/devious-maids",
+    "name": "Devious Maids",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Crime"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2013-06-23",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 8.5
+    },
+    "weight": 0,
+    "network": {
+        "id": 18,
+        "name": "Lifetime",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 30826,
+        "thetvdb": 261802,
+        "imdb": "tt2226342"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/3005.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/3005.jpg"
+    },
+    "summary": "<p><strong>Devious Maids</strong> is set in a world where murder and mayhem collide in the mansions of Beverly Hills' wealthiest and most powerful families. Class warfare has never been as fun and dirty as it is in the tiny enclave where the staff is as clever, witty and downright devilish as their employers. The series centers on a close-knit group of maids, Marisol, Rosie, Carmen Valentina and Zoila, who are bonded together by their jobs, life struggles and the melodramatic universe that engulfs their employers.</p>",
+    "updated": 1477730450,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/201"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/757238"
+        }
+    }
+}, {
+    "id": 202,
+    "url": "http://www.tvmaze.com/shows/202/almost-human",
+    "name": "Almost Human",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Crime", "Science-Fiction"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2013-11-17",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 7.6
+    },
+    "weight": 1,
+    "network": {
+        "id": 4,
+        "name": "FOX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 35771,
+        "thetvdb": 267702,
+        "imdb": "tt2654580"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/3020.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/3020.jpg"
+    },
+    "summary": "<p><strong>Almost Human</strong> is an action-packed police drama set 35 years in the future, when police officers are partnered with highly evolved human-like androids. The year is 2048. Meet John Kennex a cop who survived one of the most catastrophic attacks ever made against the police department. After waking up from a 17-month coma, he can't remember much - except that his partner was killed; his girlfriend, Anna Moore, left him after the attack; and he lost one of his legs and is now outfitted with a highly sophisticated synthetic appendage. Suffering from depression, mental atrophy, trauma-onset OCD, PTSD and the \"psychological rejection of his synthetic body part,\" John returns to work at the behest of longtime ally Captain Sandra Maldonado. By mandate, every cop must partner with a robot. And despite his passionate aversion to androids, John is paired up with a battle-ready MX-43. But he abruptly terminates his partnership after the robot discovers incriminating information about him. So technician Rudy Lom introduces John to Dorian, a discontinued android with unexpected emotional responses. Although such responses were deemed flaws, it is in these \"flaws\" that John relates to Dorian most. After all, John is part-machine now, and Dorian is part-human. John and Dorian's understanding of each other not only complements them, it connects them. As he adjusts to working with his new partner, John also must learn to get along with his new colleagues, including the eager and somewhat starstruck Detective Valerie Stahl and the distrustful Detective Richard Paul, who does not welcome John back with open arms. Almost Human will follow the week-to-week missions of John and Dorian, as they fight crime across this futuristic landscape, while the mysteries surrounding his attack and the larger mythology of this new world unfold.</p>",
+    "updated": 1491175493,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/202"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/13408"
+        }
+    }
+}, {
+    "id": 203,
+    "url": "http://www.tvmaze.com/shows/203/the-carrie-diaries",
+    "name": "The Carrie Diaries",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Comedy"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2013-01-14",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 5.8
+    },
+    "weight": 0,
+    "network": {
+        "id": 5,
+        "name": "The CW",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 30716,
+        "thetvdb": 257454,
+        "imdb": "tt2056366"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/3037.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/3037.jpg"
+    },
+    "summary": "<p>It's the summer of 1985, and, for the first time, 17-year-old Carrie Bradshaw can call Manhattan home. After her boyfriend Sebastian and best friend Maggie betrayed her, Carrie is happy to accept the offer to spend the summer living in the downtown loft apartment of her Interview magazine boss Larissa But as summer turns to fall and Carrie heads into her senior year, she and her friends and family discover that letting go of old loves and embracing new dreams comes with some tough new realities but also incredible new opportunities.</p>",
+    "updated": 1462856923,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/203"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/13435"
+        }
+    }
+}, {
+    "id": 204,
+    "url": "http://www.tvmaze.com/shows/204/stargate-sg-1",
+    "name": "Stargate SG-1",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Action", "Adventure", "Science-Fiction"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "1997-07-27",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 9.3
+    },
+    "weight": 1,
+    "network": {
+        "id": 16,
+        "name": "Syfy",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 5325,
+        "thetvdb": 72449,
+        "imdb": "tt0118480"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/3027.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/3027.jpg"
+    },
+    "summary": "<p><strong>Stargate SG-1</strong> is a science fiction series based on the original film <em>Stargate</em>. It involves the team SG-1 going on various adventures to different alien worlds through Stargates. Throughout the series they encounter various alien threats and allies including but not limited to the Goa'uld and the Asgard.</p>",
+    "updated": 1485031636,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/204"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/13649"
+        }
+    }
+}, {
+    "id": 205,
+    "url": "http://www.tvmaze.com/shows/205/graceland",
+    "name": "Graceland",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2013-06-06",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Thursday"]
+    },
+    "rating": {
+        "average": 6.8
+    },
+    "weight": 0,
+    "network": {
+        "id": 30,
+        "name": "USA Network",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 32188,
+        "thetvdb": 260338,
+        "imdb": "tt2393813"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/54/137054.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/54/137054.jpg"
+    },
+    "summary": "<p>Every year, the top graduates from the FBI Academy move from their classrooms at Quantico to their first assignments in the real world. For Agent Mike Warren, the dream has always been a post in Washington D.C. But the powers that be have other plans, and the young rookie is soon packing his bags for Graceland, a palatial beachfront mansion in Southern California that has become a cross-departmental boarding house for top undercover agents in the FBI, DEA and ICE.</p>",
+    "updated": 1476083144,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/205"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/201514"
+        }
+    }
+}, {
+    "id": 206,
+    "url": "http://www.tvmaze.com/shows/206/stargate-atlantis",
+    "name": "Stargate Atlantis",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Action", "Adventure", "Science-Fiction"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2004-07-16",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 8.9
+    },
+    "weight": 0,
+    "network": {
+        "id": 16,
+        "name": "Syfy",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 5324,
+        "thetvdb": 70851,
+        "imdb": "tt0374455"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/3059.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/3059.jpg"
+    },
+    "summary": "<p>Atlantis, built thousands of years ago by the highly evolved Ancients, is home base for an elite expedition from Earth. These courageous military commanders and scientists leap through the city's Stargate to explore the wondrous Pegasus galaxy and battle the treacherous Wraith, who seek control of Atlantis -- at any cost.</p>",
+    "updated": 1480450964,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/206"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/13782"
+        }
+    }
+}, {
+    "id": 207,
+    "url": "http://www.tvmaze.com/shows/207/stargate-universe",
+    "name": "Stargate Universe",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Action", "Adventure", "Science-Fiction"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2009-10-02",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 8
+    },
+    "weight": 0,
+    "network": {
+        "id": 16,
+        "name": "Syfy",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 15343,
+        "thetvdb": 83237,
+        "imdb": "tt1286039"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/81/204195.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/81/204195.jpg"
+    },
+    "summary": "<p><strong>Stargate Universe</strong> follows a band of soldiers, scientists and civilians, who must fend for themselves as they are forced through a Stargate when their hidden base comes under attack. The desperate survivors emerge aboard an ancient ship, which is locked on an unknown course and unable to return to Earth. Faced with meeting the most basic needs of food, water and air, the group must unlock the secrets of the ship's Stargate to survive. The danger, adventure and hope they find on board the Destiny will reveal the heroes and villains among them.</p>",
+    "updated": 1477262097,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/207"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/13822"
+        }
+    }
+}, {
+    "id": 208,
+    "url": "http://www.tvmaze.com/shows/208/the-chair",
+    "name": "The Chair",
+    "type": "Reality",
+    "language": "English",
+    "genres": [],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2014-09-06",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Saturday"]
+    },
+    "rating": {
+        "average": null
+    },
+    "weight": 0,
+    "network": {
+        "id": 17,
+        "name": "starz",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 40116,
+        "thetvdb": 284458,
+        "imdb": "tt3569344"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/3167.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/3167.jpg"
+    },
+    "summary": "<p><strong><em>\"The Chair\"</em></strong> is a competition documentary series that follows two directors through the process of bringing their first feature to the screen. The up-and-coming directors, who have unique backgrounds and skill sets, will be provided with an identical screenplay which they must craft as their own film. <em>The Chair</em> will document the creation, marketing and theatrical release of both adaptations, which will also air on STARZ. Both directors will be given the same budget, and both versions will use locations in the same city. Through multiplatform voting, the audience will determine which director will be awarded $250,000.</p>",
+    "updated": 1463559803,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/208"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/40003"
+        }
+    }
+}, {
+    "id": 209,
+    "url": "http://www.tvmaze.com/shows/209/survivors-remorse",
+    "name": "Survivor's Remorse",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Comedy"],
+    "status": "Running",
+    "runtime": 30,
+    "premiered": "2014-10-04",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 9
+    },
+    "weight": 73,
+    "network": {
+        "id": 17,
+        "name": "Starz",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": {
+        "id": 46,
+        "name": "Starz Play",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "externals": {
+        "tvrage": 37574,
+        "thetvdb": 282402,
+        "imdb": "tt3231022"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/3168.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/3168.jpg"
+    },
+    "summary": "<p><strong>Survivor's Remorse</strong> follows Cam Calloway, a basketball phenom in his early 20's who is suddenly thrust into the limelight after signing a multi-million dollar contract with a professional basketball team in Atlanta. Cam, along with his cousin, and confidant Reggie Vaughn, move to Georgia to start Cam's journey to success. The two confront the challenges of carrying opportunistic family members and their strong ties to the impoverished community that they come from. Cam, Reggie, and an unforgettable group of characters wrestle with the rewards and pitfalls of stardom, love, and loyalty.</p>",
+    "updated": 1493570752,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/209"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/894521"
+        }
+    }
+}, {
+    "id": 210,
+    "url": "http://www.tvmaze.com/shows/210/doctor-who",
+    "name": "Doctor Who",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Adventure", "Science-Fiction"],
+    "status": "Running",
+    "runtime": 45,
+    "premiered": "2005-03-26",
+    "schedule": {
+        "time": "",
+        "days": ["Saturday"]
+    },
+    "rating": {
+        "average": 9.1
+    },
+    "weight": 99,
+    "network": {
+        "id": 12,
+        "name": "BBC One",
+        "country": {
+            "name": "United Kingdom",
+            "code": "GB",
+            "timezone": "Europe/London"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 3332,
+        "thetvdb": 78804,
+        "imdb": "tt0436992"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/107/269260.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/107/269260.jpg"
+    },
+    "summary": "<p>Adventures across time and space with the time travelling alien and his companions.</p>",
+    "updated": 1494715675,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/210"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1060432"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1060433"
+        }
+    }
+}, {
+    "id": 211,
+    "url": "http://www.tvmaze.com/shows/211/666-park-avenue",
+    "name": "666 Park Avenue",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Mystery", "Supernatural"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2012-09-30",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Saturday"]
+    },
+    "rating": {
+        "average": 6.4
+    },
+    "weight": 0,
+    "network": {
+        "id": 3,
+        "name": "ABC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 30744,
+        "thetvdb": 256204,
+        "imdb": "tt2197797"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/3523.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/3523.jpg"
+    },
+    "summary": "<p><strong>666 Park Avenue</strong> is a supernatural drama based around the building of the same name run by Gavin Doran. The story follows a couple and mysterious happenings as they first move in to the establishment.</p>",
+    "updated": 1477140106,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/211"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/14089"
+        }
+    }
+}, {
+    "id": 212,
+    "url": "http://www.tvmaze.com/shows/212/alcatraz",
+    "name": "Alcatraz",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Science-Fiction", "Thriller"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2012-01-16",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 6.8
+    },
+    "weight": 0,
+    "network": {
+        "id": 4,
+        "name": "FOX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 27523,
+        "thetvdb": 248646,
+        "imdb": "tt1728102"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/30/77444.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/30/77444.jpg"
+    },
+    "summary": "<p>Switching between eras, <strong>Alcatraz</strong> focuses on the Alcatraz prison, which was shut down in 1963 due to unsafe conditions for its prisoners and guards. The show's premise is that both the prisoners and the guards disappeared in 1963 and have abruptly reappeared in modern-day San Francisco, where they are being tracked down by a government agency. </p>",
+    "updated": 1480897480,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/212"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/14102"
+        }
+    }
+}, {
+    "id": 213,
+    "url": "http://www.tvmaze.com/shows/213/the-gates",
+    "name": "The Gates",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Crime", "Supernatural"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2010-06-20",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 7.3
+    },
+    "weight": 0,
+    "network": {
+        "id": 3,
+        "name": "ABC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 24678,
+        "thetvdb": 158671,
+        "imdb": "tt1599357"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/3540.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/3540.jpg"
+    },
+    "summary": "<p>Nick Monohan and his family move from Chicago to a quiet, upscale planned community called <strong>The Gates</strong>, where he will be chief of police. They soon realize that their neighbors are not who they seem to be. The Gates is filled with such beings as vampires, witches, werewolves, and a succubus.</p>",
+    "updated": 1482780012,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/213"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/14116"
+        }
+    }
+}, {
+    "id": 214,
+    "url": "http://www.tvmaze.com/shows/214/kingdom",
+    "name": "Kingdom",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Family", "Sports"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2014-10-08",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Wednesday"]
+    },
+    "rating": {
+        "average": 7.9
+    },
+    "weight": 92,
+    "network": {
+        "id": 31,
+        "name": "Audience",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 45148,
+        "thetvdb": 283761,
+        "imdb": "tt3673794"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/12/31595.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/12/31595.jpg"
+    },
+    "summary": "<p>The family drama <em>Kingdom</em> is set against the gritty world of Mixed Martial Arts in Venice, California. Season two finds Alvey's improved fortunes have led to a bigger gym, but also a bigger appetite for risk. Ryan \"The Destroyer\" Wheeler defends his title, while Jay finds a new obsession. Lisa focuses on managing Alicia, an impulsive but skilled female fighter. Nate's determination to get back in the cage causes rifts with his family. And Christina gets a taste of sober life while carrying the burden of her sons' struggles—with victory comes agony and a price.</p>",
+    "updated": 1493727747,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/214"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/635165"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1036956"
+        }
+    }
+}, {
+    "id": 215,
+    "url": "http://www.tvmaze.com/shows/215/american-dad",
+    "name": "American Dad!",
+    "type": "Animation",
+    "language": "English",
+    "genres": ["Comedy"],
+    "status": "Running",
+    "runtime": 30,
+    "premiered": "2005-02-06",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 7.6
+    },
+    "weight": 98,
+    "network": {
+        "id": 32,
+        "name": "TBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 2594,
+        "thetvdb": 73141,
+        "imdb": "tt0397306"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/3570.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/3570.jpg"
+    },
+    "summary": "<p>In <strong>American Dad!</strong>, Stan Smith leads the all-American family in this animated sitcom filled \nwith wild and crazy extremes. Everyday life is taken to the limit as \nStan applies the same drastic measures used in his job at the CIA to his\n home life. Driven by machismo and the American dream, he often is blind\n to how horribly he fails at his attempts. This father might not know \nbest, but he never stops trying.</p>",
+    "updated": 1494511066,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/215"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1100568"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1100569"
+        }
+    }
+}, {
+    "id": 216,
+    "url": "http://www.tvmaze.com/shows/216/rick-and-morty",
+    "name": "Rick and Morty",
+    "type": "Animation",
+    "language": "English",
+    "genres": ["Comedy", "Adventure", "Science-Fiction"],
+    "status": "Running",
+    "runtime": 30,
+    "premiered": "2013-12-02",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Saturday"]
+    },
+    "rating": {
+        "average": 9.4
+    },
+    "weight": 99,
+    "network": {
+        "id": 10,
+        "name": "Adult Swim",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 33381,
+        "thetvdb": 275274,
+        "imdb": "tt2861424"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/3603.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/3603.jpg"
+    },
+    "summary": "<p>Rick is a mentally gifted, but sociopathic and alcoholic scientist and a grandfather to Morty; an awkward, impressionable, and somewhat spineless teenage boy. Rick moves into the family home of Morty, where he immediately becomes a bad influence.</p>",
+    "updated": 1492825650,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/216"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1119144"
+        }
+    }
+}, {
+    "id": 217,
+    "url": "http://www.tvmaze.com/shows/217/hostages",
+    "name": "Hostages",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Thriller"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2013-09-23",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 6.5
+    },
+    "weight": 0,
+    "network": {
+        "id": 2,
+        "name": "CBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 33027,
+        "thetvdb": 269642,
+        "imdb": "tt2647258"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/3617.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/3617.jpg"
+    },
+    "summary": "<p><strong>Hostages</strong> is a drama series based on the Israeli series of the same name. The series concerns the family of a doctor that is taken hostage by a group led by a rogue FBI agent. This occurs the night before surgery is due to be performed on the President.</p>",
+    "updated": 1480308764,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/217"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/14339"
+        }
+    }
+}, {
+    "id": 218,
+    "url": "http://www.tvmaze.com/shows/218/being-human",
+    "name": "Being Human",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Horror", "Romance"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2011-01-17",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 7.5
+    },
+    "weight": 0,
+    "network": {
+        "id": 16,
+        "name": "Syfy",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 24595,
+        "thetvdb": 196921,
+        "imdb": "tt1595680"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/3627.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/3627.jpg"
+    },
+    "summary": "<p><strong>Being Human</strong> is a series based on the UK series of the same name. It is a supernatural orientated around a vampire, ghost and werewolf trying to live under the same household.</p>",
+    "updated": 1485893913,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/218"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/14391"
+        }
+    }
+}, {
+    "id": 219,
+    "url": "http://www.tvmaze.com/shows/219/alphas",
+    "name": "Alphas",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Science-Fiction", "Supernatural"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2011-07-11",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 7.6
+    },
+    "weight": 0,
+    "network": {
+        "id": 16,
+        "name": "Syfy",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 19268,
+        "thetvdb": 210841,
+        "imdb": "tt1183865"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/3632.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/3632.jpg"
+    },
+    "summary": "<p><strong>Alphas</strong> is a science fiction drama focusing on a team that investigates people with supernatural abilities.</p>",
+    "updated": 1484007044,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/219"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/14415"
+        }
+    }
+}, {
+    "id": 220,
+    "url": "http://www.tvmaze.com/shows/220/crossing-lines",
+    "name": "Crossing Lines",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "Crime"],
+    "status": "To Be Determined",
+    "runtime": 60,
+    "premiered": "2013-06-23",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Thursday"]
+    },
+    "rating": {
+        "average": 8.1
+    },
+    "weight": 1,
+    "network": {
+        "id": 129,
+        "name": "TF1",
+        "country": {
+            "name": "France",
+            "code": "FR",
+            "timezone": "Europe/Paris"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 32722,
+        "thetvdb": 267970,
+        "imdb": "tt2427220"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/22/56454.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/22/56454.jpg"
+    },
+    "summary": "<p>The series taps into a fictional unit mandated by the International Criminal Court (ICC) to investigate cross-border crimes and ultimately bring global criminals to justice. <strong>Crossing Lines</strong> is set in the world's most exotic locales, where an elite team of eager cops work to solve the most notorious international crimes.</p>",
+    "updated": 1485612543,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/220"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/316052"
+        }
+    }
+}, {
+    "id": 221,
+    "url": "http://www.tvmaze.com/shows/221/rectify",
+    "name": "Rectify",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Crime"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2013-04-22",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Wednesday"]
+    },
+    "rating": {
+        "average": 8.4
+    },
+    "weight": 1,
+    "network": {
+        "id": 33,
+        "name": "Sundance TV",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 30069,
+        "thetvdb": 266609,
+        "imdb": "tt2183404"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/3655.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/3655.jpg"
+    },
+    "summary": "<p><strong>Rectify</strong> is a haunting story of a man released from prison after spending nearly two decades on death row.</p>",
+    "updated": 1482246903,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/221"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1004526"
+        }
+    }
+}, {
+    "id": 222,
+    "url": "http://www.tvmaze.com/shows/222/happyland",
+    "name": "Happyland",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Comedy"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2014-09-30",
+    "schedule": {
+        "time": "23:00",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 7.7
+    },
+    "weight": 0,
+    "network": {
+        "id": 22,
+        "name": "MTV",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 37422,
+        "thetvdb": 278446,
+        "imdb": "tt3168978"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/3681.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/3681.jpg"
+    },
+    "summary": "<p><strong><em>\"Happyland\"</em></strong> is a soapy teen dramedy exploring the underbelly of one of the country's most popular theme parks, going behind the scenes to reveal the not so magical reality of the park workers. The series centers on Lucy, the cynical teenage daughter of idealistic park princess mom, Elena. Having grown up in a world of manufactured happiness, Lucy wants to get out and experience something real. When Ian, the new park owner's son, arrives and sweeps her off her feet, Lucy is left wondering if fairy tale endings do exist after all. But when a scandalous secret turns her life upside down, she learns Happyland is far from a walk in the park.</p>",
+    "updated": 1454456887,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/222"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/40391"
+        }
+    }
+}, {
+    "id": 224,
+    "url": "http://www.tvmaze.com/shows/224/twisted",
+    "name": "Twisted",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Romance", "Thriller", "Mystery"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2013-03-19",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 6.7
+    },
+    "weight": 0,
+    "network": {
+        "id": 26,
+        "name": "FreeForm",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 32546,
+        "thetvdb": 267815,
+        "imdb": "tt2355844"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/3692.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/3692.jpg"
+    },
+    "summary": "<p>Twisted: a one-hour mystery full of twists and turns that follows Danny Desai, a charismatic 16-year-old with a troubled past who returns to his hometown after spending five years in juvenile detention. Immediately branded an outcast, Danny attempts to reconnect with his two childhood best friends, Jo and Lacey. But when a fellow student is found dead in her home, Danny instantly becomes the prime suspect and town spirals into a frenzy of suspicion and mystery. Jo and Lacey must decide if their childhood friend is unforgivable, or if he's really a victim being persecuted for his own twisted secrets.</p>",
+    "updated": 1481560770,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/224"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/14479"
+        }
+    }
+}, {
+    "id": 225,
+    "url": "http://www.tvmaze.com/shows/225/ravenswood",
+    "name": "Ravenswood",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Horror"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2013-10-22",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 6.7
+    },
+    "weight": 0,
+    "network": {
+        "id": 26,
+        "name": "FreeForm",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 35177,
+        "thetvdb": 268126,
+        "imdb": "tt2799012"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/3700.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/3700.jpg"
+    },
+    "summary": "<p><strong>Ravenswood</strong> centered on a town not far from Rosewood, Pa., which has suffered under a deadly curse for generations. Five strangers find themselves connected by this fatal curse and need to dig into the town's mysterious and terrible history before it's too late for all of them.</p><p>Spin-off from \"Pretty Little Liars\".</p>",
+    "updated": 1479223225,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/225"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/14502"
+        }
+    }
+}, {
+    "id": 226,
+    "url": "http://www.tvmaze.com/shows/226/the-crazy-ones",
+    "name": "The Crazy Ones",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2013-09-26",
+    "schedule": {
+        "time": "21:30",
+        "days": ["Thursday"]
+    },
+    "rating": {
+        "average": 7.4
+    },
+    "weight": 0,
+    "network": {
+        "id": 2,
+        "name": "CBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 34467,
+        "thetvdb": 269643,
+        "imdb": "tt2710104"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/3713.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/3713.jpg"
+    },
+    "summary": "<p><strong>The Crazy Ones</strong> is a comedy about a larger-than-life advertising genius whose unorthodox methods and unpredictable behavior would get him fired... if he weren't the boss. Simon Roberts is the head of a powerful agency, with the biggest clients and brands in the world, but even more important to him is that his daughter Sydney is by his side. As his partner, Sydney is Simon's exact opposite - focused, organized and eager to make a name for herself, but also too busy parenting her father, which she'd resent if he wasn't so brilliant at what he does. Joining them in the firm are the dashing and talented Zach art director Andrew, who's as hard-working as he is neurotic; and the beautiful and deceptively smart assistant Lauren. With his team and his daughter behind him, Simon continues to set the advertising world on fire, and it looks like they are definitely buying what these crazy ones are selling.</p>",
+    "updated": 1480385794,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/226"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/14524"
+        }
+    }
+}, {
+    "id": 227,
+    "url": "http://www.tvmaze.com/shows/227/mob-city",
+    "name": "Mob City",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Crime", "Thriller", "Mystery"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2013-12-04",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Wednesday"]
+    },
+    "rating": {
+        "average": 7.5
+    },
+    "weight": 0,
+    "network": {
+        "id": 14,
+        "name": "TNT",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 30641,
+        "thetvdb": 259632,
+        "imdb": "tt2176609"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/30/76225.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/30/76225.jpg"
+    },
+    "summary": "<p>The epic battle between a determined police chief and a dangerous mobster inflames 1940s Los Angeles in TNT's eagerly anticipated television event Mob City. This powerful drama comes to TNT from Frank Darabont, who wrote and directed the pilot and serves as executive producer on the series. Based on the critically acclaimed book L.A. Noir: The Struggle for the Soul of America's Most Seductive City, by John Buntin, Mob City opens in post-war Los Angeles, home to glamorous movie stars, powerful studio heads and returning war heroes. But it's also a city caught between a powerful and corrupt police force and an even more dangerous criminal network determined to make L.A. its West Coast base. Los Angeles Police Chief William Parker has made it his mission to free the city of criminals like Ben \"Bugsy\" Siegel and Mickey Cohen, the ruthless king of the Los Angeles underworld. Parker also won't hesitate to go after anyone from his own police force who sells out honor and duty for the sake of a big payout. To carry out his sweep of organized crime, Parker sets up a new mob task force within the LAPD. Headed by Det. Hal Morrison, the task force includes Det. Joe Teague, an ex-Marine who holds his cards close to his chest.</p>",
+    "updated": 1468777639,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/227"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/14530"
+        }
+    }
+}, {
+    "id": 228,
+    "url": "http://www.tvmaze.com/shows/228/last-resort",
+    "name": "Last Resort",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Action", "War"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2012-09-27",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Thursday"]
+    },
+    "rating": {
+        "average": 7.4
+    },
+    "weight": 67,
+    "network": {
+        "id": 3,
+        "name": "ABC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 30614,
+        "thetvdb": 255413,
+        "imdb": "tt2172103"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/3741.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/3741.jpg"
+    },
+    "summary": "<p>500 feet beneath the ocean's surface, the U.S. ballistic missile submarine Colorado receive their orders. Over a radio channel, designed only to be used if their homeland has been wiped out, they're told to fire nuclear weapons at Pakistan. Captain Marcus Chaplin demands confirmation of the orders only to be unceremoniously relieved of duty by the White House. XO Sam Kendal finds himself suddenly in charge of the submarine and facing the same difficult decision. When he also refuses to fire without confirmation of the orders, the Colorado is targeted, fired upon, and hit. The submarine and its crew find themselves crippled on the ocean floor, declared rogue enemies of their own country. Now, with nowhere left to turn, Chaplin and Kendal take the sub on the run and bring the men and women of the Colorado to an exotic island. Here they will find refuge, romance and a chance at a new life, even as they try to clear their names and get home.</p>",
+    "updated": 1493674049,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/228"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/14543"
+        }
+    }
+}, {
+    "id": 229,
+    "url": "http://www.tvmaze.com/shows/229/the-neighbors",
+    "name": "The Neighbors",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy", "Science-Fiction"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2012-09-26",
+    "schedule": {
+        "time": "20:30",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 7.4
+    },
+    "weight": 0,
+    "network": {
+        "id": 3,
+        "name": "ABC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 31677,
+        "thetvdb": 259057,
+        "imdb": "tt2182229"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/3763.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/3763.jpg"
+    },
+    "summary": "<p><strong>The Neighbors</strong> revolves around a family that has relocated to a gated townhouse community in New Jersey called \"Hidden Hills\". Upon their arrival, they discover that the entire community is populated by residents from another planet. Amongst their myriad quirks, these aliens identify themselves by the names of sports celebrities, patrol the community in golf carts, dress alike, receive nourishment through their eyes and mind by reading books rather than eating, and cry green goo from their ears. The aliens have assumed human form, but they can revert to their natural appearance by clapping their hands above their heads. They have been stuck on Earth for 10 years, still awaiting instructions to return home.</p>",
+    "updated": 1482973643,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/229"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/14593"
+        }
+    }
+}, {
+    "id": 230,
+    "url": "http://www.tvmaze.com/shows/230/go-on",
+    "name": "Go On",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2012-08-08",
+    "schedule": {
+        "time": "21:30",
+        "days": ["Thursday"]
+    },
+    "rating": {
+        "average": 6.9
+    },
+    "weight": 0,
+    "network": {
+        "id": 1,
+        "name": "NBC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 30756,
+        "thetvdb": 258616,
+        "imdb": "tt2300923"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/3773.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/3773.jpg"
+    },
+    "summary": "<p>Following the sudden death of his wife, sports radio personality Ryan King is forced to attend grief counseling. Feeling it unnecessary, he does so reluctantly, and with minimal participation, until it becomes clear that this may actually help him in unexpected ways. </p>",
+    "updated": 1485035721,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/230"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/14615"
+        }
+    }
+}, {
+    "id": 231,
+    "url": "http://www.tvmaze.com/shows/231/vegas",
+    "name": "Vegas",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2012-09-25",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Friday"]
+    },
+    "rating": {
+        "average": 7.5
+    },
+    "weight": 0,
+    "network": {
+        "id": 2,
+        "name": "CBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 31701,
+        "thetvdb": 259091,
+        "imdb": "tt2262383"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/3781.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/3781.jpg"
+    },
+    "summary": "<p><strong>Vegas</strong> is a drama inspired by the true story of former Las Vegas Sheriff Ralph Lamb, a fourth-generation rancher tasked with bringing order to Las Vegas in the 1960s, a gambling and entertainment mecca emerging from the tumbleweeds. Ralph Lamb wants to be left in peace to run his ranch, but Las Vegas is now swelling with outsiders and corruption which are intruding on his simple life. Recalling Lamb's command as a military police officer during World War II, the Mayor appeals to his sense of duty to look into a murder of a casino worker - and so begins Lamb's clash with Vincent Savino, a ruthless Chicago gangster who plans to make Vegas his own. Assisting Lamb in keeping law and order are his two deputies: his diplomatic, even-keeled brother Jack and his charming but impulsive son Dixon. Ambitious Assistant District Attorney Katherine O'Connell, who grew up on the ranch next to the Lambs, also lends a hand in preserving justice. In Vegas, two powerful men - Lamb and Savino - are engaged in a fierce battle for control of the budding oasis, and for both of them, folding is not an option. </p>",
+    "updated": 1486088404,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/231"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/14636"
+        }
+    }
+}, {
+    "id": 232,
+    "url": "http://www.tvmaze.com/shows/232/the-river",
+    "name": "The River",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Horror", "Supernatural"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2012-02-07",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 6.9
+    },
+    "weight": 0,
+    "network": {
+        "id": 3,
+        "name": "ABC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 28362,
+        "thetvdb": 248836,
+        "imdb": "tt1836195"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/3788.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/3788.jpg"
+    },
+    "summary": "<p><strong>The River</strong> follows the story of wildlife expert and TV personality Emmet Cole. Emmet set course around the world with his wife, Tess, and son, Lincoln, while filming what would become one of the most popular shows in television. After he goes missing deep in the Amazon, his family, friends and crew set out on a mysterious and deadly journey to find him. Famed explorer Dr. Emmet Cole went looking for magic deep in the uncharted Amazon and never returned. The shocking truth about his disappearance is out there, somewhere, just waiting to be discovered. To the millions of kids who grew up watching his nature show, Dr. Cole was a hero. To his own son, Lincoln he was more of an enigma. Now, six months after he vanished, Lincoln is finally ready to bury the past when Dr. Cole's emergency beacon suddenly goes off. At the urging of his mother, Tess Lincoln reluctantly joins her on a search for his father. To fund the rescue, they agree to let Dr. Cole's cagey ex-producer, Clark film the mission documentary-style.</p>",
+    "updated": 1481010567,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/232"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/14644"
+        }
+    }
+}, {
+    "id": 233,
+    "url": "http://www.tvmaze.com/shows/233/awake",
+    "name": "Awake",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Fantasy", "Thriller"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2012-03-01",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Thursday"]
+    },
+    "rating": {
+        "average": 7.4
+    },
+    "weight": 0,
+    "network": {
+        "id": 1,
+        "name": "NBC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 28361,
+        "thetvdb": 248735,
+        "imdb": "tt1839683"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/3799.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/3799.jpg"
+    },
+    "summary": "<p><strong>Awake</strong> is an intriguing drama about Detective Michael Britten who finds he's living two parallel lives. He's involved in a car accident that seems to have killed both his son and wife yet his mind creates an ingenious coping mechanism in which he now lives two separate lives - one where his wife survived and the other where his son did. Trying to regain some normalcy, Michael returns to solving crimes in both worlds with the help of two different partners, Detective Isaiah \"Bird\" Freeman and Detective Efrem Vega Michael is assigned a different case in each reality and quickly discovers that his dual existence is actually a powerful tool. He begins to solve impossible cases by using his two realities to gain unique perspectives and link clues that cross over from world to world. Helping Michael to navigate his two realities are his bureau-assigned therapists Dr. Evans and Dr. Lee While both therapists work to untangle his two worlds, Michael has no interest in proving either one is false. But when memories of the accident begin to haunt him, he is forced to confront the truth about what really happened the night of the crash.</p>",
+    "updated": 1477284326,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/233"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/14657"
+        }
+    }
+}, {
+    "id": 234,
+    "url": "http://www.tvmaze.com/shows/234/missing",
+    "name": "Missing",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Action", "Thriller"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2012-03-15",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 6.3
+    },
+    "weight": 0,
+    "network": {
+        "id": 3,
+        "name": "ABC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 28396,
+        "thetvdb": 248797,
+        "imdb": "tt1828246"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/3808.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/3808.jpg"
+    },
+    "summary": "<p>Becca Winstone learns that her son, Michael, disappears while studying abroad, and it's a race against time when she travels to Europe to track him down. A surprising turn of events reveals just how far one mother will go to protect her family. Exotic locations and thrilling twists will keep you riveted in \"Missing.\" How far would you go to save the only thing you have left in the world? At 8 years old, Michael watched as his father, CIA Agent Paul Winstone, was murdered. Now 10 years later, Paul's wife, Becca, is faced with the reality of her son growing up. When Michael is afforded the opportunity to study abroad, his mother reluctantly agrees it's time to let him go. Just a few weeks into his trip Michael disappears, and Becca immediately suspects foul play. When she arrives in Rome, she begins piecing together the clues left behind. It isn't long before the kidnappers realize they've picked a fight with the wrong woman. Becca Winstone has a secret of her own -- before Paul's death, she was also a lethal CIA Agent. But if she wants to find her son alive, Becca will have to rely on old friends and reopen old wounds. Her resourcefulness, skill and determination will be put to the test - but a mother's love knows no limits.</p>",
+    "updated": 1443050207,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/234"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/14667"
+        }
+    }
+}, {
+    "id": 235,
+    "url": "http://www.tvmaze.com/shows/235/the-new-normal",
+    "name": "The New Normal",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2012-09-10",
+    "schedule": {
+        "time": "21:30",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 6.8
+    },
+    "weight": 0,
+    "network": {
+        "id": 1,
+        "name": "NBC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 31384,
+        "thetvdb": 258979,
+        "imdb": "tt2087571"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/3817.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/3817.jpg"
+    },
+    "summary": "<p>These days, families come in all forms - single dads, double moms, sperm donors, egg donors, one-night-stand donors. Bryan and David are a Los Angeles couple and they have it all. Well, almost. With successful careers and a committed, loving partnership, there is one thing that this couple is missing: a baby. Just when they think the stars will never align, enter Goldie an extraordinary young woman with a checkered past. A midwestern waitress and single mother looking to escape her dead-end life and small-minded grandmother Goldie decides to change everything and move out west with her precocious eight year-old daughter. Desperate and broke - but also fertile - Goldie quickly becomes the guys' surrogate and quite possibly the girl of their dreams. Surrogate mother, surrogate family. </p>",
+    "updated": 1451841645,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/235"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/14689"
+        }
+    }
+}, {
+    "id": 236,
+    "url": "http://www.tvmaze.com/shows/236/gcb",
+    "name": "GCB",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Comedy", "Romance"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2012-03-04",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 8.5
+    },
+    "weight": 0,
+    "network": {
+        "id": 3,
+        "name": "ABC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 28393,
+        "thetvdb": 248839,
+        "imdb": "tt1727387"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/84/212122.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/84/212122.jpg"
+    },
+    "summary": "<p>Amanda Vaughn once the ultimate high school \"mean girl,\" is forced to return home in disgrace after her marriage ends in scandal. Amanda is nothing like the girl she was 20 years ago, but as her old classmates reacquaint themselves with the new Amanda, will her home town welcome her with open arms or seek revenge? No one in this town is a saint, but that doesn't mean they can't have a heart. As Amanda and her teenage kids try to adjust to their new lives, the ladies from her past alternate between sympathy and scheming.</p>",
+    "updated": 1479778903,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/236"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/14699"
+        }
+    }
+}, {
+    "id": 237,
+    "url": "http://www.tvmaze.com/shows/237/revolution",
+    "name": "Revolution",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Action", "Adventure", "Science-Fiction"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2012-09-17",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Wednesday"]
+    },
+    "rating": {
+        "average": 7.7
+    },
+    "weight": 97,
+    "network": {
+        "id": 1,
+        "name": "NBC",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 30897,
+        "thetvdb": 258823,
+        "imdb": "tt2070791"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/55/138043.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/55/138043.jpg"
+    },
+    "summary": "<p>What would you do without it all? In this epic adventure, a family struggles to reunite in an American landscape void of electricity: a world of empty cities, local militias and heroic freedom fighters, where every single piece of technology -- computers, planes, cars, phones, even lights -- has mysteriously blacked out forever.</p>",
+    "updated": 1493041988,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/237"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/14741"
+        }
+    }
+}, {
+    "id": 238,
+    "url": "http://www.tvmaze.com/shows/238/dallas",
+    "name": "Dallas",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Family"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2012-06-13",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 6.8
+    },
+    "weight": 0,
+    "network": {
+        "id": 14,
+        "name": "TNT",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 28960,
+        "thetvdb": 242521,
+        "imdb": "tt1723760"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/3848.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/3848.jpg"
+    },
+    "summary": "<p><strong>Dallas</strong> follows Bobby Ewing, now the senior member of the Ewing family following the death of his older brother J.R. Ewing. Following the death of his revered father, John Ross is out to prove he can be just as powerful an ally or enemy as his infamous father. Bobby's adopted son Christopher is newly single and determined to make a name for himself and his family in the world of natural gas. Elena Ramos is the former girlfriend of both John Ross and Christopher who is now blinded by thoughts of justice for previous wrongs. Pamela Rebecca Barnes is John Ross' wife and the daughter of Cliff Barnes, a longtime rival of the Ewings. She is determined to have a happy ending with her husband and make a home on Southfork Ranch. Also featured is Bobby's wife Ann and Harris Ryland, her scheming ex-husband. Emma Ryland is Ann and Harris' daughter, who has been taught by her father and grandmother.</p>",
+    "updated": 1480282431,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/238"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/14781"
+        }
+    }
+}, {
+    "id": 239,
+    "url": "http://www.tvmaze.com/shows/239/anger-management",
+    "name": "Anger Management",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2012-06-28",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 6.8
+    },
+    "weight": 0,
+    "network": {
+        "id": 13,
+        "name": "FX",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 29999,
+        "thetvdb": 253350,
+        "imdb": "tt1986770"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/3885.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/3885.jpg"
+    },
+    "summary": "<p>In <strong>Anger Management</strong>, Charlie is a non-traditional therapist specializing in anger management. He has a successful private practice, holding sessions with his group of primary patients each week, as well as performing pro-bono counseling for an inmate group at a state prison.</p>",
+    "updated": 1491163380,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/239"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/58175"
+        }
+    }
+}, {
+    "id": 240,
+    "url": "http://www.tvmaze.com/shows/240/cops",
+    "name": "Cops",
+    "type": "Reality",
+    "language": "English",
+    "genres": ["Action", "Crime"],
+    "status": "Running",
+    "runtime": 30,
+    "premiered": "1989-03-11",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Saturday"]
+    },
+    "rating": {
+        "average": 7.6
+    },
+    "weight": 89,
+    "network": {
+        "id": 34,
+        "name": "Spike",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 3138,
+        "thetvdb": 74709,
+        "imdb": "tt0096563"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/4185.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/4185.jpg"
+    },
+    "summary": "<p><strong>Cops </strong>allows viewers to ride along with the men and women of law enforcement every week as they take on everything from domestic disputes to car chases. Created by John Langley, the ground-breaking series premiered on March 11, 1989, and has aired over 900 new episodes. The show has followed officers in 140 different cities in the United States and in Hong Kong, London, and the former Soviet Union.</p>",
+    "updated": 1494060059,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/240"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1116648"
+        }
+    }
+}, {
+    "id": 241,
+    "url": "http://www.tvmaze.com/shows/241/benched",
+    "name": "Benched",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2014-10-28",
+    "schedule": {
+        "time": "22:30",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": 6.4
+    },
+    "weight": 0,
+    "network": {
+        "id": 30,
+        "name": "USA Network",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 38542,
+        "thetvdb": 277730,
+        "imdb": "tt3342592"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/4351.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/4351.jpg"
+    },
+    "summary": "<p><strong>Benched</strong> is a single-camera comedy about a high-powered corporate lawyer's fall from grace into the rough-and-tumble world of the public defenders. From ABC Signature Studio, it stars Coupe as Nina Whitley, a distinguished corporate lawyer who has given up everything in her climb to the top. However, when she's hit with her ex-fiancé's engagement announcement and learns that she hasn't made partner at her high power firm, Nina snaps -- breaking vases and burning bridges.</p><p>Now that Nina is shunned from the corporate world, the only place she can get a job is at the Public Defender's office: home to the underfunded, understaffed, overworked, \"if you can't afford a lawyer, one will be provided... \" lawyers. In addition to her new clients, Nina must learn to connect with her co-workers, including the roguish Phil, the idealistic Carlos, the useless empathetic Cheryl and the dedicated intern Micah. If that didn't sound tough enough for Nina, she'll also be going head-to-head with her ex-fiancé, Trent, the rising star of the District Attorney's office.</p>",
+    "updated": 1477308577,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/241"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/57311"
+        }
+    }
+}, {
+    "id": 242,
+    "url": "http://www.tvmaze.com/shows/242/the-great-fire",
+    "name": "The Great Fire",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2014-10-16",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Thursday"]
+    },
+    "rating": {
+        "average": 8
+    },
+    "weight": 0,
+    "network": {
+        "id": 35,
+        "name": "ITV",
+        "country": {
+            "name": "United Kingdom",
+            "code": "GB",
+            "timezone": "Europe/London"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 43397,
+        "thetvdb": 286969,
+        "imdb": "tt3629782"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/4358.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/4358.jpg"
+    },
+    "summary": "<p>As the great fire tears London apart, this brand new epic drama details the heart-wrenching stories of a city and its people in crisis.</p>",
+    "updated": 1479223504,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/242"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/15829"
+        }
+    }
+}, {
+    "id": 243,
+    "url": "http://www.tvmaze.com/shows/243/conan",
+    "name": "Conan",
+    "type": "Talk Show",
+    "language": "English",
+    "genres": ["Comedy"],
+    "status": "Running",
+    "runtime": 60,
+    "premiered": "2010-11-08",
+    "schedule": {
+        "time": "23:00",
+        "days": ["Monday", "Tuesday", "Wednesday", "Thursday"]
+    },
+    "rating": {
+        "average": 8.4
+    },
+    "weight": 97,
+    "network": {
+        "id": 32,
+        "name": "TBS",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 25927,
+        "thetvdb": 194751,
+        "imdb": "tt1637574"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/4583.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/4583.jpg"
+    },
+    "summary": "<p><strong>Conan</strong> has the biggest celebrities, the hottest musical guests, the craziest sketches...and Andy Richter, to boot? Yes, some would say Conan O'Brien's talk show on TBS has MORE...</p>",
+    "updated": 1494066169,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/243"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/1162877"
+        },
+        "nextepisode": {
+            "href": "http://api.tvmaze.com/episodes/1162878"
+        }
+    }
+}, {
+    "id": 244,
+    "url": "http://www.tvmaze.com/shows/244/strange-empire",
+    "name": "Strange Empire",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Western"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2014-10-06",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Monday"]
+    },
+    "rating": {
+        "average": 7.3
+    },
+    "weight": 0,
+    "network": {
+        "id": 36,
+        "name": "CBC",
+        "country": {
+            "name": "Canada",
+            "code": "CA",
+            "timezone": "Canada/Atlantic"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 43191,
+        "thetvdb": 282216,
+        "imdb": "tt3920814"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/4585.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/4585.jpg"
+    },
+    "summary": "<p><em>Strange Empire</em> is a Western whose heroes are women. With most of their men gone, and those who remain battling for control, the women struggle to survive, to find their independence, and to build a life in which to thrive and raise families. As the stories of Janestown's citizens unfold we see the clash between a power-hungry father and son and the deep prejudices among races, but also the start of something akin to community in this Wild West. Western stories take civilization as a goal; they begin in blood, and end in the morality of Main Street.</p>",
+    "updated": 1476978912,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/244"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/57603"
+        }
+    }
+}, {
+    "id": 245,
+    "url": "http://www.tvmaze.com/shows/245/town-of-the-living-dead",
+    "name": "Town of the Living Dead",
+    "type": "Reality",
+    "language": "English",
+    "genres": [],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2014-10-07",
+    "schedule": {
+        "time": "22:00",
+        "days": ["Tuesday"]
+    },
+    "rating": {
+        "average": null
+    },
+    "weight": 0,
+    "network": {
+        "id": 16,
+        "name": "Syfy",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 44602,
+        "thetvdb": 282253,
+        "imdb": "tt4081326"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/4590.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/4590.jpg"
+    },
+    "summary": "<p>In <strong>Town of the Living Dead</strong> the colorful folks of Jasper, Alabama are determined, once and for all, to complete their zombie movie, Thr33 Days Dead... now six long years in the making. Based on a town urban legend, their film centers on a group of friends trying to survive a zombie apocalypse in rural Alabama. The series will follow the intrepid and motley crew of amateur filmmakers as they struggle against every obstacle imaginable to get to a final cut of their film... which could someday become a Syfy movie.</p>",
+    "updated": 1477453208,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/245"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/40945"
+        }
+    }
+}, {
+    "id": 246,
+    "url": "http://www.tvmaze.com/shows/246/long-shadow",
+    "name": "Long Shadow",
+    "type": "Documentary",
+    "language": "English",
+    "genres": ["War", "History"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2014-09-24",
+    "schedule": {
+        "time": "20:00",
+        "days": ["Wednesday"]
+    },
+    "rating": {
+        "average": null
+    },
+    "weight": 0,
+    "network": {
+        "id": 37,
+        "name": "BBC Two",
+        "country": {
+            "name": "United Kingdom",
+            "code": "GB",
+            "timezone": "Europe/London"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 44987,
+        "thetvdb": 286553,
+        "imdb": "tt5969822"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/4591.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/4591.jpg"
+    },
+    "summary": "<p>David Reynolds traces the legacy of the Great War across 100 years and 10 different countries, examining how the war haunted a generation and shaped the peace that followed.</p>",
+    "updated": 1481568449,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/246"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/16521"
+        }
+    }
+}, {
+    "id": 247,
+    "url": "http://www.tvmaze.com/shows/247/the-colbert-report",
+    "name": "The Colbert Report",
+    "type": "Talk Show",
+    "language": "English",
+    "genres": ["Comedy"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "2005-10-17",
+    "schedule": {
+        "time": "23:30",
+        "days": ["Monday", "Tuesday", "Wednesday", "Thursday"]
+    },
+    "rating": {
+        "average": 7.5
+    },
+    "weight": 0,
+    "network": {
+        "id": 23,
+        "name": "Comedy Central",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 6715,
+        "thetvdb": 79274,
+        "imdb": "tt0458254"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/4592.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/4592.jpg"
+    },
+    "summary": "<p><span>Feel the news along with Stephen Colbert, America's ballsiest pundit</span>.</p>",
+    "updated": 1491367612,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/247"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/60538"
+        }
+    }
+}, {
+    "id": 248,
+    "url": "http://www.tvmaze.com/shows/248/transporter-the-series",
+    "name": "Transporter: The Series",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Action", "Adventure"],
+    "status": "Ended",
+    "runtime": 60,
+    "premiered": "2013-01-04",
+    "schedule": {
+        "time": "21:00",
+        "days": ["Sunday"]
+    },
+    "rating": {
+        "average": 7.5
+    },
+    "weight": 0,
+    "network": {
+        "id": 38,
+        "name": "The Movie Network",
+        "country": {
+            "name": "Canada",
+            "code": "CA",
+            "timezone": "Canada/Atlantic"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 27190,
+        "thetvdb": 248962,
+        "imdb": "tt1885102"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/4593.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/4593.jpg"
+    },
+    "summary": "<p>Frank Martin returns as the Transporter with one very simple task - to deliver the package against all the odds. However, something that sounds so simple, is rarely so.</p><p>Joined by two new team members, Caterina Boldieu, an ex- DGSE agent and later in the series, Jules Faroux, a computer and mechanical whizz, Frank is hired to deliver a diverse range of packages - from pop princesses to priceless paintings.</p><p>Frank Martin takes the jobs no other transporter will touch or can achieve - simply because they are too challenging and the odds seemingly insurmountable. That is why he is considered the best transporter in the world.</p><p>Frank's jobs take him to many beautiful locations around the world, but they also draw him into danger and mystery. And more often than not, solving that mystery will lead Frank to successfully completing his mission.</p><p>However Frank's jobs aren't solely about the packages he must deliver but also about the people he meets. While his emphasis is always on completing the mission, Frank is unable to avoid the human emotions that come with dealing with clients in difficult situations - no matter how hard he tries.</p>",
+    "updated": 1458697799,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/248"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/44358"
+        }
+    }
+}, {
+    "id": 249,
+    "url": "http://www.tvmaze.com/shows/249/the-daily-show-with-jon-stewart",
+    "name": "The Daily Show with Jon Stewart",
+    "type": "Talk Show",
+    "language": "English",
+    "genres": ["Comedy"],
+    "status": "Ended",
+    "runtime": 30,
+    "premiered": "1996-07-22",
+    "schedule": {
+        "time": "23:00",
+        "days": ["Monday", "Tuesday", "Wednesday", "Thursday"]
+    },
+    "rating": {
+        "average": 8.8
+    },
+    "weight": 0,
+    "network": {
+        "id": 23,
+        "name": "Comedy Central",
+        "country": {
+            "name": "United States",
+            "code": "US",
+            "timezone": "America/New_York"
+        }
+    },
+    "webChannel": null,
+    "externals": {
+        "tvrage": 5714,
+        "thetvdb": 71256,
+        "imdb": "tt0115147"
+    },
+    "image": {
+        "medium": "http://static.tvmaze.com/uploads/images/medium_portrait/1/4598.jpg",
+        "original": "http://static.tvmaze.com/uploads/images/original_untouched/1/4598.jpg"
+    },
+    "summary": "<p>One anchor, several correspondents, zero credibility.</p><p> If you're tired of the stodginess of the evening newscasts and you can't bear to sit through the spinmeisters and shills on the 24-hour cable news network, don't miss <strong><em>\"The Daily Show with Jon Stewart\"</em></strong>, the nightly half-hour series unburdened by objectivity, journalistic integrity or even accuracy.</p>",
+    "updated": 1469400964,
+    "link": {
+        "self": {
+            "href": "http://api.tvmaze.com/shows/249"
+        },
+        "previousepisode": {
+            "href": "http://api.tvmaze.com/episodes/201574"
+        }
+    }
+}]


### PR DESCRIPTION
Since CouchDB 2.0 now is possible to retrieve documents using Mango Query

https://blog.couchdb.org/2016/08/03/feature-mango-query/