### PR TITLE
Add method bulkGet

### DIFF
--- a/lib/Doctrine/CouchDB/CouchDBClient.php
+++ b/lib/Doctrine/CouchDB/CouchDBClient.php
@@ -809,4 +809,27 @@ class CouchDBClient
 
         return $response->body;
     }
+
+    /**
+     * Get changes.
+     *
+     * @param array $params
+     *
+     * @throws HTTPException
+     *
+     * @return array
+     */
+    public function bulkGet(array $docs = [])
+    {
+        $path = '/'.$this->databaseName.'/_bulk_get';
+
+        $response = $this->httpClient->request('POST', $path, json_encode(['docs' => $docs]));
+
+        if ($response->status != 200) {
+            throw HTTPException::fromResponse($path, $response);
+        }
+
+
+        return $response->body;
+    }
 }

--- a/lib/Doctrine/CouchDB/CouchDBClient.php
+++ b/lib/Doctrine/CouchDB/CouchDBClient.php
@@ -811,9 +811,9 @@ class CouchDBClient
     }
 
     /**
-     * Get changes.
+     * Bulk get.
      *
-     * @param array $params
+     * @param array $docs
      *
      * @throws HTTPException
      *


### PR DESCRIPTION
This method can be called to query several documents in bulk. It is well suited for fetching a specific revision of documents, as replicators do for example, or for getting revision history.