### PR TITLE
Support HTTP "201 created" and "202 accepted" for database operations

### DIFF
--- a/lib/Doctrine/CouchDB/CouchDBClient.php
+++ b/lib/Doctrine/CouchDB/CouchDBClient.php
@@ -360,7 +360,7 @@ class CouchDBClient
     {
         $response = $this->httpClient->request('DELETE', '/'.urlencode($name));
 
-        if ($response->status != 200 && $response->status != 404) {
+        if (!(in_array($response->status, [200,202,404]))) {
             throw HTTPException::fromResponse('/'.urlencode($name), $response);
         }
     }

--- a/lib/Doctrine/CouchDB/CouchDBClient.php
+++ b/lib/Doctrine/CouchDB/CouchDBClient.php
@@ -360,7 +360,7 @@ class CouchDBClient
     {
         $response = $this->httpClient->request('DELETE', '/'.urlencode($name));
 
-        if (! in_array($response->status, [200,202,404])) {
+        if (!in_array($response->status, [200,201,202,404])) {
             throw HTTPException::fromResponse('/'.urlencode($name), $response);
         }
     }

--- a/lib/Doctrine/CouchDB/CouchDBClient.php
+++ b/lib/Doctrine/CouchDB/CouchDBClient.php
@@ -360,7 +360,7 @@ class CouchDBClient
     {
         $response = $this->httpClient->request('DELETE', '/'.urlencode($name));
 
-        if (!(in_array($response->status, [200,202,404]))) {
+        if (! in_array($response->status, [200,202,404])) {
             throw HTTPException::fromResponse('/'.urlencode($name), $response);
         }
     }


### PR DESCRIPTION
On clustered CouchDB servers creating a doc or DB may return HTTP 201 and deleting a DB may return HTTP 202


Please see further reference at: https://docs.couchdb.org/en/stable/api/basics.html#http-status-codes

```
201 - Created
Document created successfully.

202 - Accepted
Request has been accepted, but the corresponding operation may not have completed. This is used for background operations, such as database compaction.


```